### PR TITLE
any_of and any_of_equal call std::find_if and std::find respectively

### DIFF
--- a/include/boost/algorithm/cxx11/any_of.hpp
+++ b/include/boost/algorithm/cxx11/any_of.hpp
@@ -35,10 +35,7 @@ using std::any_of;      // Section 25.2.2
 template<typename InputIterator, typename Predicate> 
 bool any_of ( InputIterator first, InputIterator last, Predicate p ) 
 {
-    for ( ; first != last; ++first )
-        if ( p(*first)) 
-            return true;
-    return false; 
+    return std::find_if(first, last, p) != last;
 } 
 #endif
 
@@ -66,10 +63,7 @@ bool any_of ( const Range &r, Predicate p )
 template<typename InputIterator, typename V> 
 bool any_of_equal ( InputIterator first, InputIterator last, const V &val ) 
 {
-    for ( ; first != last; ++first )
-        if ( val == *first )
-            return true;
-    return false; 
+    return std::find(first, last, val) != last;
 } 
 
 /// \fn any_of_equal ( const Range &r, const V &val )


### PR DESCRIPTION
any_of calls std::find and checks against range end. STL implementations should be trusted to perform this more efficiently than the hand-written search.

All tests pass.
