### PR TITLE
initialize member variables

### DIFF
--- a/include/boost/algorithm/string/find_iterator.hpp
+++ b/include/boost/algorithm/string/find_iterator.hpp
@@ -230,7 +230,12 @@ namespace boost {
     
                 \post eof()==true
             */
-            split_iterator() { m_bEof = true; }
+            split_iterator() :
+            m_Next(),
+            m_End(),
+            m_bEof(true)
+            {}
+
             //! Copy constructor
             /*!
                 Construct a copy of the split_iterator


### PR DESCRIPTION
m_Next and m_End are not objects, so do not have constructors, and so are not initialized without explicit value initialization.
Also moved the value initialization of m_bEof into the initializer list for consistency's sake.
This was uncovered by Coverity issue CID10557.