### PR TITLE
Fix missing include <iterator>

### DIFF
--- a/minmax/example/minmax_ex.cpp
+++ b/minmax/example/minmax_ex.cpp
@@ -8,6 +8,7 @@
 #include <cstdlib>
 #include <cassert>
 #include <iostream>
+#include <iterator>
 
 #include <boost/algorithm/minmax.hpp>
 #include <boost/algorithm/minmax_element.hpp>


### PR DESCRIPTION
I got compilation error, because of using of undeclared identifier 'front_inserter'.
I checked that [std::front_inseter](http://www.cplusplus.com/reference/iterator/front_inserter) is defined at [\<iterator\>](http://www.cplusplus.com/reference/iterator) header, which probably is missed here. 

So this fix is just about adding one more include of  [\<iterator\>](http://www.cplusplus.com/reference/iterator) to the sample.

Checked with VS 2015 community.