### PR TITLE
Remove some includes, fix some comments and docs

### DIFF
--- a/doc/all_of.qbk
+++ b/doc/all_of.qbk
@@ -73,7 +73,7 @@ All of the variants of `all_of` and `all_of_equal` take their parameters by valu
 
 [heading Notes]
 
-* The routine `all_of` is part of the C++11 standard. When compiled using a C++11 implementation, the implementation from the standard library will be used.
+* The routine `all_of` is also available as part of the C++11 standard.
 
 * `all_of` and `all_of_equal` both return true for empty ranges, no matter what is passed to test against. When there are no items in the sequence to test, they all satisfy the condition to be tested against.
 

--- a/doc/any_of.qbk
+++ b/doc/any_of.qbk
@@ -73,7 +73,7 @@ All of the variants of `any_of` and `any_of_equal` take their parameters by valu
 
 [heading Notes]
 
-* The routine `any_of` is part of the C++11 standard. When compiled using a C++11 implementation, the implementation from the standard library will be used.
+* The routine `any_of` is also available as part of the C++11 standard.
 
 * `any_of` and `any_of_equal` both return false for empty ranges, no matter what is passed to test against. 
 

--- a/doc/is_partitioned.qbk
+++ b/doc/is_partitioned.qbk
@@ -55,7 +55,7 @@ Both of the variants of `is_partitioned` take their parameters by value or const
 
 [heading Notes]
 
-* The iterator-based version of the routine `is_partitioned` is part of the C++11 standard. When compiled using a C++11 implementation, the implementation from the standard library will be used.
+* The iterator-based version of the routine `is_partitioned` is also available as part of the C++11 standard.
 
 * `is_partitioned` returns true for empty ranges, no matter what predicate is passed to test against. 
 

--- a/doc/is_permutation.qbk
+++ b/doc/is_permutation.qbk
@@ -71,7 +71,7 @@ All of the variants of `is_permutation` take their parameters by value, and do n
 
 [heading Notes]
 
-* The three iterator versions of the routine `is_permutation` are part of the C++11 standard. When compiled using a C++11 implementation, the implementation from the standard library will be used.
+* The three iterator versions of the routine `is_permutation` are also available as part of the C++11 standard.
 
 * The four iterator versions of the routine `is_permutation` are part of the proposed C++14 standard. When C++14 standard libraries become available, the implementation should be changed to use the implementation from the standard library (if available).
 

--- a/doc/none_of.qbk
+++ b/doc/none_of.qbk
@@ -74,7 +74,7 @@ All of the variants of `none_of` and `none_of_equal` take their parameters by va
 
 [heading Notes]
 
-* The routine `none_of` is part of the C++11 standard. When compiled using a C++11 implementation, the implementation from the standard library will be used.
+* The routine `none_of` is also available aspart of the C++11 standard.
 
 * `none_of` and `none_of_equal` both return true for empty ranges, no matter what is passed to test against. 
 

--- a/doc/none_of.qbk
+++ b/doc/none_of.qbk
@@ -74,7 +74,7 @@ All of the variants of `none_of` and `none_of_equal` take their parameters by va
 
 [heading Notes]
 
-* The routine `none_of` is also available aspart of the C++11 standard.
+* The routine `none_of` is also available as part of the C++11 standard.
 
 * `none_of` and `none_of_equal` both return true for empty ranges, no matter what is passed to test against. 
 

--- a/doc/partition_point.qbk
+++ b/doc/partition_point.qbk
@@ -54,7 +54,7 @@ Both of the variants of `partition_point` take their parameters by value or cons
 
 [heading Notes]
 
-* The iterator-based version of the routine `partition_point` is part of the C++11 standard. When compiled using a C++11 implementation, the implementation from the standard library will be used.
+* The iterator-based version of the routine `partition_point` is also available as part of the C++11 standard.
 
 * For empty ranges, the partition point is the end of the range.
 

--- a/include/boost/algorithm/cxx11/all_of.hpp
+++ b/include/boost/algorithm/cxx11/all_of.hpp
@@ -12,7 +12,6 @@
 #ifndef BOOST_ALGORITHM_ALL_OF_HPP
 #define BOOST_ALGORITHM_ALL_OF_HPP
 
-#include <algorithm>    // for std::all_of, if available
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 
@@ -27,8 +26,6 @@ namespace boost { namespace algorithm {
 /// \param p     A predicate for testing the elements of the sequence
 ///
 /// \note           This function is part of the C++2011 standard library.
-///  We will use the standard one if it is available, 
-///  otherwise we have our own implementation.
 template<typename InputIterator, typename Predicate> 
 bool all_of ( InputIterator first, InputIterator last, Predicate p )
 {

--- a/include/boost/algorithm/cxx11/any_of.hpp
+++ b/include/boost/algorithm/cxx11/any_of.hpp
@@ -14,7 +14,6 @@
 #ifndef BOOST_ALGORITHM_ANY_OF_HPP
 #define BOOST_ALGORITHM_ANY_OF_HPP
 
-#include <algorithm>    // for std::any_of, if available
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 

--- a/include/boost/algorithm/cxx11/copy_if.hpp
+++ b/include/boost/algorithm/cxx11/copy_if.hpp
@@ -12,7 +12,7 @@
 #ifndef BOOST_ALGORITHM_COPY_IF_HPP
 #define BOOST_ALGORITHM_COPY_IF_HPP
 
-#include <algorithm>    // for std::copy_if, if available
+#include <utility>    // for std::pair, std::make_pair
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 
@@ -28,8 +28,6 @@ namespace boost { namespace algorithm {
 /// \param result   An output iterator to write the results into
 /// \param p        A predicate for testing the elements of the range
 /// \note           This function is part of the C++2011 standard library.
-///  We will use the standard one if it is available, 
-///  otherwise we have our own implementation.
 template<typename InputIterator, typename OutputIterator, typename Predicate> 
 OutputIterator copy_if ( InputIterator first, InputIterator last, OutputIterator result, Predicate p )
 {

--- a/include/boost/algorithm/cxx11/copy_n.hpp
+++ b/include/boost/algorithm/cxx11/copy_n.hpp
@@ -12,8 +12,6 @@
 #ifndef BOOST_ALGORITHM_COPY_N_HPP
 #define BOOST_ALGORITHM_COPY_N_HPP
 
-#include <algorithm>    // for std::copy_n, if available
-
 namespace boost { namespace algorithm {
 
 /// \fn copy_n ( InputIterator first, Size n, OutputIterator result )
@@ -25,8 +23,6 @@ namespace boost { namespace algorithm {
 /// \param n        The number of elements to copy
 /// \param result   An output iterator to write the results into
 /// \note           This function is part of the C++2011 standard library.
-///  We will use the standard one if it is available, 
-///     otherwise we have our own implementation.
 template <typename InputIterator, typename Size, typename OutputIterator>
 OutputIterator copy_n ( InputIterator first, Size n, OutputIterator result )
 {

--- a/include/boost/algorithm/cxx11/find_if_not.hpp
+++ b/include/boost/algorithm/cxx11/find_if_not.hpp
@@ -12,8 +12,6 @@
 #ifndef BOOST_ALGORITHM_FIND_IF_NOT_HPP
 #define BOOST_ALGORITHM_FIND_IF_NOT_HPP
 
-#include <algorithm>    // for std::find_if_not, if it exists
-
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 
@@ -27,8 +25,6 @@ namespace boost { namespace algorithm {
 /// \param last     One past the end of the input sequence
 /// \param p        A predicate for testing the elements of the range
 /// \note           This function is part of the C++2011 standard library.
-///  We will use the standard one if it is available, 
-///  otherwise we have our own implementation.
 template<typename InputIterator, typename Predicate> 
 InputIterator find_if_not ( InputIterator first, InputIterator last, Predicate p )
 {

--- a/include/boost/algorithm/cxx11/iota.hpp
+++ b/include/boost/algorithm/cxx11/iota.hpp
@@ -12,8 +12,6 @@
 #ifndef BOOST_ALGORITHM_IOTA_HPP
 #define BOOST_ALGORITHM_IOTA_HPP
 
-#include <numeric>
-
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 
@@ -26,8 +24,6 @@ namespace boost { namespace algorithm {
 /// \param last     One past the end of the input sequence
 /// \param value    The initial value of the sequence to be generated
 /// \note           This function is part of the C++2011 standard library.
-///  We will use the standard one if it is available, 
-///  otherwise we have our own implementation.
 template <typename ForwardIterator, typename T>
 void iota ( ForwardIterator first, ForwardIterator last, T value )
 {

--- a/include/boost/algorithm/cxx11/is_partitioned.hpp
+++ b/include/boost/algorithm/cxx11/is_partitioned.hpp
@@ -12,8 +12,6 @@
 #ifndef BOOST_ALGORITHM_IS_PARTITIONED_HPP
 #define BOOST_ALGORITHM_IS_PARTITIONED_HPP
 
-#include <algorithm>    // for std::is_partitioned, if available
-
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 
@@ -26,8 +24,6 @@ namespace boost { namespace algorithm {
 /// \param last     One past the end of the input sequence
 /// \param p        The predicate to test the values with
 /// \note           This function is part of the C++2011 standard library.
-///  We will use the standard one if it is available, 
-///  otherwise we have our own implementation.
 template <typename InputIterator, typename UnaryPredicate>
 bool is_partitioned ( InputIterator first, InputIterator last, UnaryPredicate p )
 {

--- a/include/boost/algorithm/cxx11/is_permutation.hpp
+++ b/include/boost/algorithm/cxx11/is_permutation.hpp
@@ -12,8 +12,8 @@
 #ifndef BOOST_ALGORITHM_IS_PERMUTATION11_HPP
 #define BOOST_ALGORITHM_IS_PERMUTATION11_HPP
 
-#include <algorithm>    // for std::less, tie, mismatch and is_permutation (if available)
-#include <utility>      // for std::make_pair
+#include <algorithm>    // for std::find_if, count_if, mismatch
+#include <utility>      // for std::pair
 #include <functional>   // for std::equal_to
 #include <iterator>
 
@@ -108,8 +108,6 @@ namespace detail {
 /// \param p        The predicate to compare elements with
 ///
 /// \note           This function is part of the C++2011 standard library.
-///  We will use the standard one if it is available,
-///     otherwise we have our own implementation.
 template< class ForwardIterator1, class ForwardIterator2, class BinaryPredicate >
 bool is_permutation ( ForwardIterator1 first1, ForwardIterator1 last1,
                       ForwardIterator2 first2, BinaryPredicate p )
@@ -135,8 +133,6 @@ bool is_permutation ( ForwardIterator1 first1, ForwardIterator1 last1,
 /// \param last2    One past the end of the input sequence
 /// \param first2   The start of the second sequence
 /// \note           This function is part of the C++2011 standard library.
-///  We will use the standard one if it is available,
-///     otherwise we have our own implementation.
 template< class ForwardIterator1, class ForwardIterator2 >
 bool is_permutation ( ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2 )
 {

--- a/include/boost/algorithm/cxx11/is_sorted.hpp
+++ b/include/boost/algorithm/cxx11/is_sorted.hpp
@@ -13,7 +13,6 @@
 #ifndef BOOST_ALGORITHM_ORDERED_HPP
 #define BOOST_ALGORITHM_ORDERED_HPP
 
-#include <algorithm>
 #include <functional>
 #include <iterator>
 

--- a/include/boost/algorithm/cxx11/none_of.hpp
+++ b/include/boost/algorithm/cxx11/none_of.hpp
@@ -12,7 +12,6 @@
 #ifndef BOOST_ALGORITHM_NONE_OF_HPP
 #define BOOST_ALGORITHM_NONE_OF_HPP
 
-#include <algorithm>    // for std::none_of, if available
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 

--- a/include/boost/algorithm/cxx11/partition_copy.hpp
+++ b/include/boost/algorithm/cxx11/partition_copy.hpp
@@ -12,8 +12,7 @@
 #ifndef BOOST_ALGORITHM_PARTITION_COPY_HPP
 #define BOOST_ALGORITHM_PARTITION_COPY_HPP
 
-#include <algorithm>    // for std::partition_copy, if available
-#include <utility>  // for make_pair
+#include <utility>  // for std::pair
 
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
@@ -34,8 +33,6 @@ namespace boost { namespace algorithm {
 /// \param p         A predicate for dividing the elements of the input sequence.
 ///
 /// \note            This function is part of the C++2011 standard library.
-///  We will use the standard one if it is available, 
-///  otherwise we have our own implementation.
 template <typename InputIterator, 
         typename OutputIterator1, typename OutputIterator2, typename UnaryPredicate>
 std::pair<OutputIterator1, OutputIterator2>

--- a/include/boost/algorithm/cxx11/partition_point.hpp
+++ b/include/boost/algorithm/cxx11/partition_point.hpp
@@ -12,7 +12,7 @@
 #ifndef BOOST_ALGORITHM_PARTITION_POINT_HPP
 #define BOOST_ALGORITHM_PARTITION_POINT_HPP
 
-#include <algorithm>    // for std::partition_point, if available
+#include <iterator>    // for std::distance, advance
 
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
@@ -27,8 +27,6 @@ namespace boost { namespace algorithm {
 /// \param last     One past the end of the input sequence
 /// \param p        The predicate to test the values with
 /// \note           This function is part of the C++2011 standard library.
-///  We will use the standard one if it is available, 
-///  otherwise we have our own implementation.
 template <typename ForwardIterator, typename Predicate>
 ForwardIterator partition_point ( ForwardIterator first, ForwardIterator last, Predicate p )
 {

--- a/include/boost/algorithm/cxx14/equal.hpp
+++ b/include/boost/algorithm/cxx14/equal.hpp
@@ -13,7 +13,8 @@
 #define BOOST_ALGORITHM_EQUAL_HPP
 
 #include <algorithm>    // for std::equal
-#include <functional>   // for std::equal_to
+#include <functional>   // for std::binary_function
+#include <iterator>
 
 namespace boost { namespace algorithm {
 

--- a/include/boost/algorithm/cxx14/is_permutation.hpp
+++ b/include/boost/algorithm/cxx14/is_permutation.hpp
@@ -12,8 +12,7 @@
 #ifndef BOOST_ALGORITHM_IS_PERMUTATION14_HPP
 #define BOOST_ALGORITHM_IS_PERMUTATION14_HPP
 
-#include <algorithm>    // for std::less, tie, mismatch and is_permutation (if available)
-#include <utility>      // for std::make_pair
+#include <utility>      // for std::pair
 #include <functional>   // for std::equal_to
 #include <iterator>
 
@@ -31,8 +30,6 @@ namespace boost { namespace algorithm {
 /// \param first2   The start of the second sequence
 /// \param last1    One past the end of the second sequence
 /// \note           This function is part of the C++2014 standard library.
-///  We will use the standard one if it is available,
-///     otherwise we have our own implementation.
 template< class ForwardIterator1, class ForwardIterator2 >
 bool is_permutation ( ForwardIterator1 first1, ForwardIterator1 last1, 
                       ForwardIterator2 first2, ForwardIterator2 last2 )
@@ -62,8 +59,6 @@ bool is_permutation ( ForwardIterator1 first1, ForwardIterator1 last1,
 /// \param pred     The predicate to compare elements with
 ///
 /// \note           This function is part of the C++2014 standard library.
-///  We will use the standard one if it is available,
-///     otherwise we have our own implementation.
 template< class ForwardIterator1, class ForwardIterator2, class BinaryPredicate >
 bool is_permutation ( ForwardIterator1 first1, ForwardIterator1 last1,
                       ForwardIterator2 first2, ForwardIterator2 last2, 

--- a/include/boost/algorithm/cxx14/mismatch.hpp
+++ b/include/boost/algorithm/cxx14/mismatch.hpp
@@ -12,7 +12,6 @@
 #ifndef BOOST_ALGORITHM_MISMATCH_HPP
 #define BOOST_ALGORITHM_MISMATCH_HPP
 
-#include <algorithm>    // for std::mismatch
 #include <utility>      // for std::pair
 
 namespace boost { namespace algorithm {


### PR DESCRIPTION
As a result of commit 4dac507 (Remove code to use standard library versions of algorithms), most of the files in cxx11 were including `<algorithm>` unnecessarily.

I suggest removing those includes where they are not used, and also removing comments which misleadingly said "We will use the standard one if it is available, otherwise we have our own implementation."

Also, the file copy_if.hpp wasn't including `<utility>` where pair and make_pair can be found, and partition_point was missing an `#include <iterator>`.

A second commit removes similar unused includes in cxx14/is_permutation.hpp and cxx14/mismatch.hpp, and adds a missing `#include <iterator>` to cxx14/equal.hpp.

A third commit removes incorrect statements from the docs.
