### PR TITLE
Remove std::*nary_function

### DIFF
--- a/include/boost/algorithm/cxx14/equal.hpp
+++ b/include/boost/algorithm/cxx14/equal.hpp
@@ -13,7 +13,6 @@
 #define BOOST_ALGORITHM_EQUAL_HPP
 
 #include <algorithm>    // for std::equal
-#include <functional>   // for std::binary_function
 #include <iterator>
 
 namespace boost { namespace algorithm {
@@ -21,9 +20,10 @@ namespace boost { namespace algorithm {
 namespace detail {
 
     template <class T1, class T2>
-    struct eq : public std::binary_function<T1, T2, bool> {
+    struct eq {
+        typedef bool result_type;
         bool operator () ( const T1& v1, const T2& v2 ) const { return v1 == v2 ;}
-        };
+    };
     
     template <class RandomAccessIterator1, class RandomAccessIterator2, class BinaryPredicate>
     bool equal ( RandomAccessIterator1 first1, RandomAccessIterator1 last1, 

--- a/include/boost/algorithm/string/detail/case_conv.hpp
+++ b/include/boost/algorithm/string/detail/case_conv.hpp
@@ -13,7 +13,6 @@
 
 #include <boost/algorithm/string/config.hpp>
 #include <locale>
-#include <functional>
 
 #include <boost/type_traits/make_unsigned.hpp>
 
@@ -30,7 +29,7 @@ namespace boost {
 
             // a tolower functor
             template<typename CharT>
-            struct to_lowerF : public std::unary_function<CharT, CharT>
+            struct to_lowerF
             {
                 // Constructor
                 to_lowerF( const std::locale& Loc ) : m_Loc( &Loc ) {}
@@ -50,7 +49,7 @@ namespace boost {
 
             // a toupper functor
             template<typename CharT>
-            struct to_upperF : public std::unary_function<CharT, CharT>
+            struct to_upperF
             {
                 // Constructor
                 to_upperF( const std::locale& Loc ) : m_Loc( &Loc ) {}

--- a/include/boost/algorithm/string/detail/util.hpp
+++ b/include/boost/algorithm/string/detail/util.hpp
@@ -12,7 +12,6 @@
 #define BOOST_STRING_UTIL_DETAIL_HPP
 
 #include <boost/algorithm/string/config.hpp>
-#include <functional>
 #include <boost/range/iterator_range_core.hpp>
 
 namespace boost {
@@ -89,8 +88,7 @@ namespace boost {
             template< 
                 typename SeqT, 
                 typename IteratorT=BOOST_STRING_TYPENAME SeqT::const_iterator >
-            struct copy_iterator_rangeF : 
-                public std::unary_function< iterator_range<IteratorT>, SeqT >
+            struct copy_iterator_rangeF
             {
                 SeqT operator()( const iterator_range<IteratorT>& Range ) const
                 {

--- a/test/all_of_test.cpp
+++ b/test/all_of_test.cpp
@@ -13,12 +13,11 @@
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 
-#include <functional>
 #include <vector>
 #include <list>
 
 template<typename T>
-struct is_ : public std::unary_function<T, bool> {
+struct is_ {
     is_ ( T v ) : val_ ( v ) {}
     ~is_ () {}
     bool operator () ( T comp ) const { return val_ == comp; }

--- a/test/any_of_test.cpp
+++ b/test/any_of_test.cpp
@@ -13,12 +13,11 @@
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 
-#include <functional>
 #include <vector>
 #include <list>
 
 template<typename T>
-struct is_ : public std::unary_function<T, bool> {
+struct is_ {
     is_ ( T v ) : val_ ( v ) {}
     ~is_ () {}
     bool operator () ( T comp ) const { return val_ == comp; }

--- a/test/none_of_test.cpp
+++ b/test/none_of_test.cpp
@@ -13,12 +13,11 @@
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 
-#include <functional>
 #include <vector>
 #include <list>
 
 template<typename T>
-struct is_ : public std::unary_function<T, bool> {
+struct is_ {
     is_ ( T v ) : val_ ( v ) {}
     ~is_ () {}
     bool operator () ( T comp ) const { return val_ == comp; }

--- a/test/one_of_test.cpp
+++ b/test/one_of_test.cpp
@@ -13,12 +13,11 @@
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 
-#include <functional>
 #include <vector>
 #include <list>
 
 template<typename T>
-struct is_ : public std::unary_function<T, bool> {
+struct is_ {
     is_ ( T v ) : val_ ( v ) {}
     ~is_ () {}
     bool operator () ( T comp ) const { return val_ == comp; }


### PR DESCRIPTION
You asked me to remind you about PR #17 / commit 3aef0ab so you could merge to master.

Also, in C++17, std::unary_function and std::binary_function will be removed from the standard, so we should also remove their uses.

I brought this up on the mailing list: [What to do about std::binary_function and std::unary_function?](http://lists.boost.org/Archives/boost/2016/05/229402.php)
There was not a lot of response, but the slight preponderance of opinion seemed to be to just remove the inheritance: everything should keep working, but maybe provide a typedef for result_type for use with boost::bind.

I did that. I didn't add the typedef for the structs in `detail` since they are "internal."
