### PR TITLE
Remove unused bad include

### DIFF
--- a/include/boost/algorithm/hex.hpp
+++ b/include/boost/algorithm/hex.hpp
@@ -25,7 +25,9 @@
 
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
-#include <boost/exception/all.hpp>
+#include <boost/exception/exception.hpp>
+#include <boost/exception/info.hpp>
+#include <boost/throw_exception.hpp>
 
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_integral.hpp>


### PR DESCRIPTION
boost/exception/errinfo_errno.hpp, included in boost/exception/all.hpp, pushes the warning level to 1 on MSVC, but emits a level 1 warning with /sdl. Only exception.hpp and throw_exception.hpp are necessary.