### PR TITLE
Fix MSVC warnings in tests

### DIFF
--- a/test/copy_if_test1.cpp
+++ b/test/copy_if_test1.cpp
@@ -28,8 +28,8 @@
 namespace ba = boost::algorithm;
 // namespace ba = boost;
 
-BOOST_CXX14_CONSTEXPR bool is_true  ( int v ) { return true; }
-BOOST_CXX14_CONSTEXPR bool is_false ( int v ) { return false; }
+BOOST_CXX14_CONSTEXPR bool is_true  ( int ) { return true; }
+BOOST_CXX14_CONSTEXPR bool is_false ( int ) { return false; }
 BOOST_CXX14_CONSTEXPR bool is_even  ( int v ) { return v % 2 == 0; }
 BOOST_CXX14_CONSTEXPR bool is_odd   ( int v ) { return v % 2 == 1; }
 BOOST_CXX14_CONSTEXPR bool is_zero  ( int v ) { return v == 0; }

--- a/test/hex_test4.cpp
+++ b/test/hex_test4.cpp
@@ -25,7 +25,7 @@ void test_short_input1 () {
     std::string s;
     
     try { ba::unhex ( std::string ( "A" ), std::back_inserter(s)); }
-    catch ( const std::exception &ex ) { return; }
+    catch ( const std::exception & ) { return; }
     BOOST_TEST_MESSAGE ( "Failed to catch std::exception in test_short_input1" );
     BOOST_CHECK ( false );
     }
@@ -34,7 +34,7 @@ void test_short_input2 () {
     std::string s;
     
     try { ba::unhex ( std::string ( "A" ), std::back_inserter(s)); }
-    catch ( const ba::hex_decode_error &ex ) { return; }
+    catch ( const ba::hex_decode_error & ) { return; }
     BOOST_TEST_MESSAGE ( "Failed to catch ba::hex_decode_error in test_short_input2" );
     BOOST_CHECK ( false );
     }
@@ -43,7 +43,7 @@ void test_short_input3 () {
     std::string s;
     
     try { ba::unhex ( std::string ( "A" ), std::back_inserter(s)); }
-    catch ( const ba::not_enough_input &ex ) { return; }
+    catch ( const ba::not_enough_input & ) { return; }
     BOOST_TEST_MESSAGE ( "Failed to catch ba::not_enough_input in test_short_input3" );
     BOOST_CHECK ( false );
     }
@@ -53,8 +53,8 @@ void test_short_input4 () {
     std::string s;
     
     try { ba::unhex ( std::string ( "A" ), std::back_inserter(s)); }
-    catch ( const ba::non_hex_input &ex ) { BOOST_CHECK ( false ); }
-    catch ( const ba::not_enough_input &ex ) { return; }
+    catch ( const ba::non_hex_input & ) { BOOST_CHECK ( false ); }
+    catch ( const ba::not_enough_input & ) { return; }
     catch ( ... ) { BOOST_CHECK ( false ); }
     BOOST_CHECK ( false );
     }
@@ -64,8 +64,8 @@ void test_short_input5 () {
     std::string s;
     
     try { ba::unhex ( "A", std::back_inserter(s)); }
-    catch ( const ba::non_hex_input &ex ) { BOOST_CHECK ( false ); }
-    catch ( const ba::not_enough_input &ex ) { return; }
+    catch ( const ba::non_hex_input & ) { BOOST_CHECK ( false ); }
+    catch ( const ba::not_enough_input & ) { return; }
     catch ( ... ) { BOOST_CHECK ( false ); }
     BOOST_CHECK ( false );
     }
@@ -125,8 +125,8 @@ void test_nonhex_input4 () {
     std::string s;
     
     try { ba::unhex ( "P1234FA1234", std::back_inserter(s)); }
-    catch ( const ba::not_enough_input &ex ) { BOOST_CHECK ( false ); }
-    catch ( const ba::non_hex_input &ex ) { return; }
+    catch ( const ba::not_enough_input & ) { BOOST_CHECK ( false ); }
+    catch ( const ba::non_hex_input & ) { return; }
     catch ( ... ) { BOOST_CHECK ( false ); }
     BOOST_CHECK ( false );
     }

--- a/test/is_permutation_test1.cpp
+++ b/test/is_permutation_test1.cpp
@@ -112,7 +112,7 @@ void test_sequence1 () {
     std::vector<int> v, v1;
     
     v.clear ();
-    for ( std::size_t i = 5; i < 15; ++i )
+    for ( int i = 5; i < 15; ++i )
         v.push_back ( i );
     v1 = v;
     BOOST_CHECK ( ba::is_permutation ( v.begin (), v.end (), v.begin ()));  // better be a permutation of itself!

--- a/test/search_test1.cpp
+++ b/test/search_test1.cpp
@@ -32,7 +32,7 @@ namespace {
 
 //  Check using iterators
     template<typename Container>
-    void check_one_iter ( const Container &haystack, const std::string &needle, int expected ) {
+    void check_one_iter ( const Container &haystack, const std::string &needle, std::ptrdiff_t expected ) {
         typedef typename Container::const_iterator iter_type;
         typedef typename std::pair<iter_type, iter_type> ret_type;
         typedef std::string::const_iterator pattern_type;
@@ -53,7 +53,7 @@ namespace {
 //         iter_type it1r = ret1r.first;
 //         iter_type it2  = ret2.first;
 //         iter_type it3  = ret3.first;
-        const int dist = ret1.first == hEnd ? -1 : std::distance ( hBeg, ret1.first );
+        const std::ptrdiff_t dist = ret1.first == hEnd ? -1 : std::distance ( hBeg, ret1.first );
 
         std::cout << "(Iterators) Pattern is " << needle.length () << ", haysstack is " << haystack.length () << " chars long; " << std::endl;
         try {
@@ -97,7 +97,7 @@ namespace {
 //  Check using pointers
 //    We're assuming that the container implements contiguous storage here.
     template<typename Container>
-    void check_one_pointer ( const Container &haystack, const std::string &needle, int expected ) {
+    void check_one_pointer ( const Container &haystack, const std::string &needle, std::ptrdiff_t expected ) {
         typedef const typename Container::value_type *ptr_type;
         typedef typename std::pair<ptr_type, ptr_type> ret_type;
 
@@ -110,7 +110,7 @@ namespace {
         ret_type ret1 = ba::boyer_moore_search          (hBeg, hEnd, nBeg, nEnd);
         ret_type ret2 = ba::boyer_moore_horspool_search (hBeg, hEnd, nBeg, nEnd);
         ret_type ret3 = ba::knuth_morris_pratt_search   (hBeg, hEnd, nBeg, nEnd);
-        const int dist = ret1.first == hEnd ? -1 : std::distance ( hBeg, ret1.first );
+        const std::ptrdiff_t dist = ret1.first == hEnd ? -1 : std::distance ( hBeg, ret1.first );
 
         std::cout << "(Pointers) Pattern is " << needle.length () << ", haysstack is " << haystack.length () << " chars long; " << std::endl;
         try {
@@ -147,7 +147,7 @@ namespace {
 
 //  Check using objects
     template<typename Container>
-    void check_one_object ( const Container &haystack, const std::string &needle, int expected ) {
+    void check_one_object ( const Container &haystack, const std::string &needle, std::ptrdiff_t expected ) {
         typedef typename Container::const_iterator iter_type;
         typedef typename std::pair<iter_type, iter_type> ret_type;
         typedef std::string::const_iterator pattern_type;
@@ -169,7 +169,7 @@ namespace {
        ret_type retr1r = bm_r         (haystack);
         ret_type ret2   = bmh          (hBeg, hEnd);
         ret_type ret3   = kmp          (hBeg, hEnd);
-        const int dist  = ret1.first == hEnd ? -1 : std::distance ( hBeg, ret1.first );
+        const std::ptrdiff_t dist  = ret1.first == hEnd ? -1 : std::distance ( hBeg, ret1.first );
 
         std::cout << "(Objects) Pattern is " << needle.length () << ", haysstack is " << haystack.length () << " chars long; " << std::endl;
         try {
@@ -224,7 +224,7 @@ namespace {
 
 
     template<typename Container>
-    void check_one ( const Container &haystack, const std::string &needle, int expected ) {
+    void check_one ( const Container &haystack, const std::string &needle, std::ptrdiff_t expected ) {
         check_one_iter ( haystack, needle, expected );
         check_one_pointer ( haystack, needle, expected );
         check_one_object ( haystack, needle, expected );

--- a/test/search_test2.cpp
+++ b/test/search_test2.cpp
@@ -85,7 +85,7 @@ namespace {
         std::cout << std::endl;
         }
     
-    void check_one ( const vec &haystack, const vec &needle, int expected ) {
+    void check_one ( const vec &haystack, const vec &needle, std::ptrdiff_t expected ) {
         std::size_t i;
         std::clock_t sTime;
         unsigned long stdDiff;
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE( test_main )
     std::cout << "---- Middle -----" << std::endl;
     check_one ( c1, p1f, -2 );      //  Don't know answer
     std::cout << "------ End ------" << std::endl;
-    check_one ( c1, p1e, c1.size() - p1e.size ());  
+    check_one ( c1, p1e, static_cast<std::ptrdiff_t>(c1.size() - p1e.size ()));  
     std::cout << "--- Not found ---" << std::endl;
     check_one ( c1, p1n, -1 );      //  Not found
     }

--- a/test/search_test3.cpp
+++ b/test/search_test3.cpp
@@ -85,7 +85,7 @@ namespace {
         std::cout << std::endl;
         }
     
-    void check_one ( const vec &haystack, const vec &needle, int expected ) {
+    void check_one ( const vec &haystack, const vec &needle, std::ptrdiff_t expected ) {
         std::size_t i;
         std::clock_t sTime;
         unsigned long stdDiff;
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE( test_main )
     std::cout << "---- Middle -----" << std::endl;
     check_one ( c1, p1f, -2 );      //  Don't know answer
     std::cout << "------ End ------" << std::endl;
-    check_one ( c1, p1e, c1.size() - p1e.size ());  
+    check_one ( c1, p1e, static_cast<std::ptrdiff_t>(c1.size() - p1e.size ()));  
     std::cout << "--- Not found ---" << std::endl;
     check_one ( c1, p1n, -1 );      //  Not found
     }

--- a/test/search_test4.cpp
+++ b/test/search_test4.cpp
@@ -62,7 +62,7 @@ namespace {
         return retVal;
         }
     
-    void check_one ( const vec &haystack, const vec &needle, int expected ) {
+    void check_one ( const vec &haystack, const vec &needle, std::ptrdiff_t expected ) {
         
         std::pair<vec::const_iterator, vec::const_iterator> res;
         std::pair<vec::const_iterator, vec::const_iterator> exp;        // the expected result
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE( test_main )
     std::cout << "---- Middle -----" << std::endl;
     check_one ( c1, p1f, -2 );      //  Don't know answer
     std::cout << "------ End ------" << std::endl;
-    check_one ( c1, p1e, c1.size() - p1e.size ());  
+    check_one ( c1, p1e, static_cast<std::ptrdiff_t>(c1.size() - p1e.size ()));  
     std::cout << "--- Not found ---" << std::endl;
     check_one ( c1, p1n, -1 );      //  Not found
     }


### PR DESCRIPTION
MSVC complains about narrowing conversions and unreferences parameters.
This makes all tests almost level 4 warning clean on MSVC 14.