### PR TITLE
replace deprecated binders and adapters, and random_shuffle by more m…

### DIFF
--- a/include/boost/algorithm/cxx14/equal.hpp
+++ b/include/boost/algorithm/cxx14/equal.hpp
@@ -21,7 +21,7 @@ namespace boost { namespace algorithm {
 namespace detail {
 
     template <class T1, class T2>
-    struct eq : public std::binary_function<T1, T2, bool> {
+    struct eq {
         bool operator () ( const T1& v1, const T2& v2 ) const { return v1 == v2 ;}
         };
     

--- a/include/boost/algorithm/string/detail/case_conv.hpp
+++ b/include/boost/algorithm/string/detail/case_conv.hpp
@@ -30,7 +30,7 @@ namespace boost {
 
             // a tolower functor
             template<typename CharT>
-            struct to_lowerF : public std::unary_function<CharT, CharT>
+            struct to_lowerF
             {
                 // Constructor
                 to_lowerF( const std::locale& Loc ) : m_Loc( &Loc ) {}
@@ -50,7 +50,7 @@ namespace boost {
 
             // a toupper functor
             template<typename CharT>
-            struct to_upperF : public std::unary_function<CharT, CharT>
+            struct to_upperF
             {
                 // Constructor
                 to_upperF( const std::locale& Loc ) : m_Loc( &Loc ) {}

--- a/include/boost/algorithm/string/detail/util.hpp
+++ b/include/boost/algorithm/string/detail/util.hpp
@@ -89,8 +89,7 @@ namespace boost {
             template< 
                 typename SeqT, 
                 typename IteratorT=BOOST_STRING_TYPENAME SeqT::const_iterator >
-            struct copy_iterator_rangeF : 
-                public std::unary_function< iterator_range<IteratorT>, SeqT >
+            struct copy_iterator_rangeF
             {
                 SeqT operator()( const iterator_range<IteratorT>& Range ) const
                 {

--- a/minmax/test/minmax_element_test.cpp
+++ b/minmax/test/minmax_element_test.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 #include <list>
 #include <set>
+#include <random>
 #include <cstdlib>
 
 #include <boost/config.hpp> /* prevents some nasty warns in MSVC */
@@ -19,6 +20,15 @@
 
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
+
+namespace boost { namespace detail {
+
+inline std::random_device & get_common_random_device() {
+	static std::random_device generator;
+	return generator;
+}
+
+}}
 
 class custom {
   int m_x;
@@ -223,7 +233,7 @@ void test(int n BOOST_APPEND_EXPLICIT_TEMPLATE_TYPE(Value))
   test_range(first, last, n);
 
   // Populate test vector with random values
-  std::random_shuffle(first, last);
+  std::shuffle(first, last, std::default_random_engine(boost::detail::get_common_random_device()()));
   test_range(first, last, n);
 }
 

--- a/test/all_of_test.cpp
+++ b/test/all_of_test.cpp
@@ -18,7 +18,7 @@
 #include <list>
 
 template<typename T>
-struct is_ : public std::unary_function<T, bool> {
+struct is_ {
     is_ ( T v ) : val_ ( v ) {}
     ~is_ () {}
     bool operator () ( T comp ) const { return val_ == comp; }

--- a/test/any_of_test.cpp
+++ b/test/any_of_test.cpp
@@ -18,7 +18,7 @@
 #include <list>
 
 template<typename T>
-struct is_ : public std::unary_function<T, bool> {
+struct is_ {
     is_ ( T v ) : val_ ( v ) {}
     ~is_ () {}
     bool operator () ( T comp ) const { return val_ == comp; }

--- a/test/none_of_test.cpp
+++ b/test/none_of_test.cpp
@@ -18,7 +18,7 @@
 #include <list>
 
 template<typename T>
-struct is_ : public std::unary_function<T, bool> {
+struct is_ {
     is_ ( T v ) : val_ ( v ) {}
     ~is_ () {}
     bool operator () ( T comp ) const { return val_ == comp; }

--- a/test/one_of_test.cpp
+++ b/test/one_of_test.cpp
@@ -18,7 +18,7 @@
 #include <list>
 
 template<typename T>
-struct is_ : public std::unary_function<T, bool> {
+struct is_ {
     is_ ( T v ) : val_ ( v ) {}
     ~is_ () {}
     bool operator () ( T comp ) const { return val_ == comp; }

--- a/test/partition_subrange_test.cpp
+++ b/test/partition_subrange_test.cpp
@@ -7,6 +7,7 @@
 
 #include <vector>
 #include <iostream>
+#include <random>
 namespace ba = boost::algorithm;
 
 template <typename Iter>
@@ -58,6 +59,8 @@ void check_sequence ( Iter first, Iter last, Iter sf, Iter sl, Pred p )
 
 BOOST_AUTO_TEST_CASE( test_main )
 {
+    std::default_random_engine gen;
+
 	{
 	std::vector<int> v;
 	for ( int i = 0; i < 10; ++i )
@@ -72,14 +75,14 @@ BOOST_AUTO_TEST_CASE( test_main )
 // 	BOOST_CHECK_EQUAL(v[5], 5);
 	
 //	Mix them up and try again - single element
-	std::random_shuffle(v.begin(), v.end());
+	std::shuffle(v.begin(), v.end(), gen);
 	ba::partition_subrange(b, v.end(), b + 7, b + 8);
 	check_sequence        (b, v.end(), b + 7, b + 8);
 
 // 	BOOST_CHECK_EQUAL(v[7], 7);
 
 //	Mix them up and try again - at the end
-	std::random_shuffle(v.begin(), v.end());
+	std::shuffle(v.begin(), v.end(), gen);
 	ba::partition_subrange(b, v.end(), b + 7, v.end());
 	check_sequence        (b, v.end(), b + 7, v.end());
 
@@ -88,7 +91,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 // 	BOOST_CHECK_EQUAL(v[9], 9);
 
 //	Mix them up and try again - at the beginning
-	std::random_shuffle(v.begin(), v.end());
+	std::shuffle(v.begin(), v.end(), gen);
 	ba::partition_subrange(b, v.end(), b, b + 2);
 	check_sequence        (b, v.end(), b, b + 2);
 
@@ -96,12 +99,12 @@ BOOST_AUTO_TEST_CASE( test_main )
 // 	BOOST_CHECK_EQUAL(v[1], 1);
 
 //	Mix them up and try again - empty subrange
-	std::random_shuffle(v.begin(), v.end());
+	std::shuffle(v.begin(), v.end(), gen);
 	ba::partition_subrange(b, v.end(), b, b);
 	check_sequence        (b, v.end(), b, b);
 
 //	Mix them up and try again - entire subrange
-	std::random_shuffle(v.begin(), v.end());
+	std::shuffle(v.begin(), v.end(), gen);
 	ba::partition_subrange(b, v.end(), b, v.end());
 	check_sequence        (b, v.end(), b, v.end());
 	}
@@ -120,14 +123,14 @@ BOOST_AUTO_TEST_CASE( test_main )
 // 	BOOST_CHECK_EQUAL(v[5], 4);
 
 //	Mix them up and try again - single element
-	std::random_shuffle(v.begin(), v.end());
+	std::shuffle(v.begin(), v.end(), gen);
 	ba::partition_subrange(b, v.end(), b + 7, b + 8, std::greater<int>());
 	check_sequence        (b, v.end(), b + 7, b + 8, std::greater<int>());
 
 // 	BOOST_CHECK_EQUAL(v[7], 2);
 
 //	Mix them up and try again - at the end
-	std::random_shuffle(v.begin(), v.end());
+	std::shuffle(v.begin(), v.end(), gen);
 	ba::partition_subrange(b, v.end(), b + 7, v.end(), std::greater<int>());
 	check_sequence        (b, v.end(), b + 7, v.end(), std::greater<int>());
 
@@ -136,7 +139,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 // 	BOOST_CHECK_EQUAL(v[9], 0);
 
 //	Mix them up and try again - at the beginning
-	std::random_shuffle(v.begin(), v.end());
+	std::shuffle(v.begin(), v.end(), gen);
 	ba::partition_subrange(b, v.end(), b, b + 2, std::greater<int>());
 	check_sequence        (b, v.end(), b, b + 2, std::greater<int>());
 
@@ -144,12 +147,12 @@ BOOST_AUTO_TEST_CASE( test_main )
 // 	BOOST_CHECK_EQUAL(v[1], 8);
 
 //	Mix them up and try again - empty subrange
-	std::random_shuffle(v.begin(), v.end());
+	std::shuffle(v.begin(), v.end(), gen);
 	ba::partition_subrange(b, v.end(), b, b, std::greater<int>());
 	check_sequence        (b, v.end(), b, b, std::greater<int>());
 
 //	Mix them up and try again - entire subrange
-	std::random_shuffle(v.begin(), v.end());
+	std::shuffle(v.begin(), v.end(), gen);
 	ba::partition_subrange(b, v.end(), b, v.end(), std::greater<int>());
 	check_sequence        (b, v.end(), b, v.end(), std::greater<int>());
 	}

--- a/test/sort_subrange_test.cpp
+++ b/test/sort_subrange_test.cpp
@@ -7,6 +7,7 @@
 
 #include <vector>
 #include <iostream>
+#include <random>
 namespace ba = boost::algorithm;
 
 template <typename Iter>
@@ -39,6 +40,8 @@ void check_sequence ( Iter first, Iter last, Iter sf, Iter sl, Pred p )
 
 BOOST_AUTO_TEST_CASE( test_main )
 {
+    std::default_random_engine gen;
+
 	{
 	std::vector<int> v;
 	for ( int i = 0; i < 10; ++i )
@@ -53,14 +56,14 @@ BOOST_AUTO_TEST_CASE( test_main )
 	BOOST_CHECK_EQUAL(v[5], 5);
 	
 //	Mix them up and try again - single element
-	std::random_shuffle(v.begin(), v.end());
+	std::shuffle(v.begin(), v.end(), gen);
 	ba::sort_subrange(b, v.end(), b + 7, b + 8);
 	check_sequence   (b, v.end(), b + 7, b + 8);
 
 	BOOST_CHECK_EQUAL(v[7], 7);
 
 //	Mix them up and try again - at the end
-	std::random_shuffle(v.begin(), v.end());
+	std::shuffle(v.begin(), v.end(), gen);
 	ba::sort_subrange(b, v.end(), b + 7, v.end());
 	check_sequence   (b, v.end(), b + 7, v.end());
 
@@ -69,7 +72,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 	BOOST_CHECK_EQUAL(v[9], 9);
 
 //	Mix them up and try again - at the beginning
-	std::random_shuffle(v.begin(), v.end());
+	std::shuffle(v.begin(), v.end(), gen);
 	ba::sort_subrange(b, v.end(), b, b + 2);
 	check_sequence   (b, v.end(), b, b + 2);
 
@@ -77,12 +80,12 @@ BOOST_AUTO_TEST_CASE( test_main )
 	BOOST_CHECK_EQUAL(v[1], 1);
 
 //	Mix them up and try again - empty subrange
-	std::random_shuffle(v.begin(), v.end());
+	std::shuffle(v.begin(), v.end(), gen);
 	ba::sort_subrange(b, v.end(), b, b);
 	check_sequence   (b, v.end(), b, b);
 
 //	Mix them up and try again - entire subrange
-	std::random_shuffle(v.begin(), v.end());
+	std::shuffle(v.begin(), v.end(), gen);
 	ba::sort_subrange(b, v.end(), b, v.end());
 	check_sequence   (b, v.end(), b, v.end());
 	}
@@ -101,14 +104,14 @@ BOOST_AUTO_TEST_CASE( test_main )
 	BOOST_CHECK_EQUAL(v[5], 4);
 
 //	Mix them up and try again - single element
-	std::random_shuffle(v.begin(), v.end());
+	std::shuffle(v.begin(), v.end(), gen);
 	ba::sort_subrange(b, v.end(), b + 7, b + 8, std::greater<int>());
 	check_sequence   (b, v.end(), b + 7, b + 8, std::greater<int>());
 
 	BOOST_CHECK_EQUAL(v[7], 2);
 
 //	Mix them up and try again - at the end
-	std::random_shuffle(v.begin(), v.end());
+	std::shuffle(v.begin(), v.end(), gen);
 	ba::sort_subrange(b, v.end(), b + 7, v.end(), std::greater<int>());
 	check_sequence   (b, v.end(), b + 7, v.end(), std::greater<int>());
 
@@ -117,7 +120,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 	BOOST_CHECK_EQUAL(v[9], 0);
 
 //	Mix them up and try again - at the beginning
-	std::random_shuffle(v.begin(), v.end());
+	std::shuffle(v.begin(), v.end(), gen);
 	ba::sort_subrange(b, v.end(), b, b + 2, std::greater<int>());
 	check_sequence   (b, v.end(), b, b + 2, std::greater<int>());
 
@@ -125,12 +128,12 @@ BOOST_AUTO_TEST_CASE( test_main )
 	BOOST_CHECK_EQUAL(v[1], 8);
 
 //	Mix them up and try again - empty subrange
-	std::random_shuffle(v.begin(), v.end());
+	std::shuffle(v.begin(), v.end(), gen);
 	ba::sort_subrange(b, v.end(), b, b, std::greater<int>());
 	check_sequence   (b, v.end(), b, b, std::greater<int>());
 
 //	Mix them up and try again - entire subrange
-	std::random_shuffle(v.begin(), v.end());
+	std::shuffle(v.begin(), v.end(), gen);
 	ba::sort_subrange(b, v.end(), b, v.end(), std::greater<int>());
 	check_sequence   (b, v.end(), b, v.end(), std::greater<int>());
 	}


### PR DESCRIPTION
**replace deprecated binders and adapters, and random_shuffle by more modern equivalents**

Required with latest msvc versions and compiler option /std:c++latest