### PR TITLE
Build the algorithm documentation standalone.

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -47,10 +47,10 @@ boostbook standalone
 
 ###############################################################################
 alias boostdoc
-    : algorithm ../string/doc/string_algo.xml
+    : ../string/doc/string_algo.xml
     :
-    : <dependency>autodoc <dependency>../string/doc//autodoc
+    : <dependency>../string/doc//autodoc
     : ;
 explicit boostdoc ;
-alias boostrelease ;
+alias boostrelease : standalone ;
 explicit boostrelease ;


### PR DESCRIPTION
In the release candidate the algorithm documentation is being built as part of the combined documentation, which means it isn't in its normal location. So this changes it to build as standalone documentation again.