### PR TITLE
Conditionally replace deprecated c++98 features by c++11 ones

### DIFF
--- a/minmax/test/minmax_element_test.cpp
+++ b/minmax/test/minmax_element_test.cpp
@@ -20,6 +20,19 @@
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 
+#if (__cplusplus >= 201103L) || defined(BOOST_NO_CXX98_RANDOM_SHUFFLE)
+#include <random>
+
+std::default_random_engine gen;
+template<typename RandomIt>
+void do_shuffle(RandomIt first, RandomIt last)
+{ std::shuffle(first, last, gen); }
+#else
+template<typename RandomIt>
+void do_shuffle(RandomIt first, RandomIt last)
+{ std::random_shuffle(first, last); }
+#endif
+
 class custom {
   int m_x;
   friend bool operator<(custom const& x, custom const& y);
@@ -117,7 +130,7 @@ void test_minmax(CIterator first, CIterator last, int n)
 
   CHECK_EQUAL_ITERATORS( min, std::min_element(first, last), first );
   CHECK_EQUAL_ITERATORS( max, std::max_element(first, last), first );
-  
+
   // second version, comp function object (keeps a counter!)
   lc.reset();
   tie( boost::minmax_element(first, last, lc), min, max );
@@ -183,7 +196,7 @@ void test_minmax(CIterator first, CIterator last, int n)
 
 template <class Container, class Iterator, class Value>
 void test_container(Iterator first, Iterator last, int n,
-                    Container* dummy = 0
+                    Container* /* dummy */ = 0
                     BOOST_APPEND_EXPLICIT_TEMPLATE_TYPE(Value) )
 {
   Container c(first, last);
@@ -223,7 +236,7 @@ void test(int n BOOST_APPEND_EXPLICIT_TEMPLATE_TYPE(Value))
   test_range(first, last, n);
 
   // Populate test vector with random values
-  std::random_shuffle(first, last);
+  do_shuffle(first, last);
   test_range(first, last, n);
 }
 

--- a/test/partition_subrange_test.cpp
+++ b/test/partition_subrange_test.cpp
@@ -8,7 +8,7 @@
 #include <vector>
 #include <iostream>
 
-#if __cplusplus >= 201103L
+#if (__cplusplus >= 201103L) || defined(BOOST_NO_CXX98_RANDOM_SHUFFLE)
 #include <random>
 
 std::default_random_engine gen;
@@ -34,7 +34,7 @@ void check_sequence ( Iter first, Iter last, Iter sf, Iter sl )
 // 		}
 // 	if (sl == last) std::cout << "<";
 // 	std::cout << '\n';
-	
+
 	if (sf == sl) return;
 	for (Iter i = first; i < sf; ++i)
 		BOOST_CHECK(*i < *sf);
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 	std::vector<int> v;
 	for ( int i = 0; i < 10; ++i )
 		v.push_back(i);
-	
+
 	const std::vector<int>::iterator b = v.begin();
 	ba::partition_subrange(b, v.end(), b + 3, b + 6);
 	check_sequence        (b, v.end(), b + 3, b + 6);
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 // 	BOOST_CHECK_EQUAL(v[3], 3);
 // 	BOOST_CHECK_EQUAL(v[4], 4);
 // 	BOOST_CHECK_EQUAL(v[5], 5);
-	
+
 //	Mix them up and try again - single element
 	do_shuffle(v.begin(), v.end());
 	ba::partition_subrange(b, v.end(), b + 7, b + 8);
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 	std::vector<int> v;
 	for ( int i = 0; i < 10; ++i )
 		v.push_back(i);
-	
+
 	const std::vector<int>::iterator b = v.begin();
 	ba::partition_subrange(b, v.end(), b + 3, b + 6, std::greater<int>());
 	check_sequence        (b, v.end(), b + 3, b + 6, std::greater<int>());

--- a/test/sort_subrange_test.cpp
+++ b/test/sort_subrange_test.cpp
@@ -8,7 +8,7 @@
 #include <vector>
 #include <iostream>
 
-#if __cplusplus >= 201103L
+#if (__cplusplus >= 201103L) || defined(BOOST_NO_CXX98_RANDOM_SHUFFLE)
 #include <random>
 
 std::default_random_engine gen;
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 	std::vector<int> v;
 	for ( int i = 0; i < 10; ++i )
 		v.push_back(i);
-	
+
 	const std::vector<int>::iterator b = v.begin();
 	ba::sort_subrange(b, v.end(), b + 3, b + 6);
 	check_sequence   (b, v.end(), b + 3, b + 6);
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 	BOOST_CHECK_EQUAL(v[3], 3);
 	BOOST_CHECK_EQUAL(v[4], 4);
 	BOOST_CHECK_EQUAL(v[5], 5);
-	
+
 //	Mix them up and try again - single element
 	do_shuffle(v.begin(), v.end());
 	ba::sort_subrange(b, v.end(), b + 7, b + 8);
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 	std::vector<int> v;
 	for ( int i = 0; i < 10; ++i )
 		v.push_back(i);
-	
+
 	const std::vector<int>::iterator b = v.begin();
 	ba::sort_subrange(b, v.end(), b + 3, b + 6, std::greater<int>());
 	check_sequence   (b, v.end(), b + 3, b + 6, std::greater<int>());


### PR DESCRIPTION
change std::random_shuffle -> std::shuffle + random_engine if indicated by the supported language level or Boost configuration macro.

Signed-off-by: Daniela Engert <dani@ngrt.de>