### PR TITLE
Add BOOST_CXX14_CONSTEXPR to identity_operation.

### DIFF
--- a/include/boost/algorithm/algorithm.hpp
+++ b/include/boost/algorithm/algorithm.hpp
@@ -25,10 +25,10 @@
 namespace boost { namespace algorithm {
 
 template <typename T>
-T identity_operation ( std::multiplies<T> ) { return T(1); }
+BOOST_CXX14_CONSTEXPR T identity_operation ( std::multiplies<T> ) { return T(1); }
 
 template <typename T>
-T identity_operation ( std::plus<T> ) { return T(0); }
+BOOST_CXX14_CONSTEXPR T identity_operation ( std::plus<T> ) { return T(0); }
 
 
 /// \fn power ( T x, Integer n )


### PR DESCRIPTION
`power(x, n, op)` uses `identity_operation` and is constexpr in C++14.

On a tangential note... shouldn't these functions be called `identity_element`?
