### PR TITLE
Satisfy cxx14 constexpr

### DIFF
--- a/include/boost/algorithm/cxx11/one_of.hpp
+++ b/include/boost/algorithm/cxx11/one_of.hpp
@@ -12,7 +12,6 @@
 #ifndef BOOST_ALGORITHM_ONE_OF_HPP
 #define BOOST_ALGORITHM_ONE_OF_HPP
 
-#include <algorithm>            // for std::find and std::find_if
 #include <boost/algorithm/cxx11/none_of.hpp>
 
 #include <boost/range/begin.hpp>
@@ -30,10 +29,12 @@ namespace boost { namespace algorithm {
 template<typename InputIterator, typename Predicate> 
 BOOST_CXX14_CONSTEXPR bool one_of ( InputIterator first, InputIterator last, Predicate p )
 {
-    InputIterator i = std::find_if (first, last, p);
-    if (i == last)
-        return false;    // Didn't occur at all
-    return boost::algorithm::none_of (++i, last, p);
+    do
+    {
+        if (first == last)
+            return false;
+    } while ( !p(*first++) );
+    return boost::algorithm::none_of (first, last, p);
 }
 
 /// \fn one_of ( const Range &r, Predicate p )
@@ -59,10 +60,12 @@ BOOST_CXX14_CONSTEXPR bool one_of ( const Range &r, Predicate p )
 template<typename InputIterator, typename V> 
 bool one_of_equal ( InputIterator first, InputIterator last, const V &val )
 {
-    InputIterator i = std::find (first, last, val); // find first occurrence of 'val'
-    if (i == last)
-        return false;                    // Didn't occur at all
-    return boost::algorithm::none_of_equal (++i, last, val);
+    do
+    {
+        if (first == last)
+            return false;
+    } while ( val != *first++ );
+    return boost::algorithm::none_of_equal (first, last, val);
 }
 
 /// \fn one_of_equal ( const Range &r, const V &val )

--- a/include/boost/algorithm/cxx14/equal.hpp
+++ b/include/boost/algorithm/cxx14/equal.hpp
@@ -40,8 +40,11 @@ namespace detail {
     //  Random-access iterators let is check the sizes in constant time
         if ( std::distance ( first1, last1 ) != std::distance ( first2, last2 ))
             return false;
-    // If we know that the sequences are the same size, the original version is fine
-        return std::equal ( first1, last1, first2, pred );
+    // If we know that the sequences are the same size, we can reduce comparison like the original version
+        for ( ; first1 != last1; ++first1, ++first2 )
+            if ( !pred(*first1, *first2) )
+                return false;
+        return true;
     }
 
     template <class InputIterator1, class InputIterator2, class BinaryPredicate>

--- a/test/clamp_test.cpp
+++ b/test/clamp_test.cpp
@@ -14,8 +14,8 @@
 
 namespace ba = boost::algorithm;
 
-bool intGreater    ( int lhs, int rhs )       { return lhs > rhs; }
-bool doubleGreater ( double lhs, double rhs ) { return lhs > rhs; }
+BOOST_CXX14_CONSTEXPR bool intGreater    ( int lhs, int rhs )       { return lhs > rhs; }
+BOOST_CXX14_CONSTEXPR bool doubleGreater ( double lhs, double rhs ) { return lhs > rhs; }
 
 class custom {
 public:
@@ -306,7 +306,7 @@ void test_constexpr()
         BOOST_CHECK(check_max_out);
     }
     {
-        short foo = 50;
+        BOOST_CXX14_CONSTEXPR short foo = 50;
         BOOST_CXX14_CONSTEXPR bool check_float   = ( 56    == ba::clamp ( foo, 56.9, 129 ));
         BOOST_CHECK(check_float);
         BOOST_CXX14_CONSTEXPR bool check_over    = ( 24910 == ba::clamp ( foo, 12345678, 123456999 ));


### PR DESCRIPTION
This PR fixes compile errors regarding c++14 constexpr:
- `one_of(_equal)` and `equal` are marked as c++14 constexpr but standard algorithms are not constexpr until c++20
- `clamp_test` tests c++14 constexpr but some objects are not constexpr

Tested compilers:
- gcc 8.0.1 20180218 (Red Hat 8.0.1-0.14) w/ cxxstd=03,11,14,17
- 6.0.0 (tags/RELEASE_600/rc2) w/ cxxstd=03,11,14,17
