### PR TITLE
functions used in constexpr context must be marked 'constexpr'

### DIFF
--- a/test/clamp_test.cpp
+++ b/test/clamp_test.cpp
@@ -14,8 +14,8 @@
 
 namespace ba = boost::algorithm;
 
-bool intGreater    ( int lhs, int rhs )       { return lhs > rhs; }
-bool doubleGreater ( double lhs, double rhs ) { return lhs > rhs; }
+BOOST_CONSTEXPR bool intGreater    ( int lhs, int rhs )       { return lhs > rhs; }
+BOOST_CONSTEXPR bool doubleGreater ( double lhs, double rhs ) { return lhs > rhs; }
 
 class custom {
 public:


### PR DESCRIPTION
Signed-off-by: Daniela Engert <dani@ngrt.de>