### PR TITLE
Use forwarding references in string/split.hpp

### DIFF
--- a/include/boost/algorithm/string/iter_find.hpp
+++ b/include/boost/algorithm/string/iter_find.hpp
@@ -71,7 +71,11 @@ namespace boost {
         inline SequenceSequenceT&
         iter_find(
             SequenceSequenceT& Result,
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+            RangeT&& Input,
+#else
             RangeT& Input,
+#endif
             FinderT Finder )
         {
             BOOST_CONCEPT_ASSERT((
@@ -142,7 +146,11 @@ namespace boost {
         inline SequenceSequenceT&
         iter_split(
             SequenceSequenceT& Result,
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+            RangeT&& Input,
+#else
             RangeT& Input,
+#endif
             FinderT Finder )
         {
             BOOST_CONCEPT_ASSERT((

--- a/include/boost/algorithm/string/split.hpp
+++ b/include/boost/algorithm/string/split.hpp
@@ -61,7 +61,11 @@ namespace boost {
         template< typename SequenceSequenceT, typename Range1T, typename Range2T >
         inline SequenceSequenceT& find_all(
             SequenceSequenceT& Result,
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+            Range1T&& Input,
+#else
             Range1T& Input,
+#endif
             const Range2T& Search)
         {
             return ::boost::algorithm::iter_find(
@@ -96,7 +100,11 @@ namespace boost {
         template< typename SequenceSequenceT, typename Range1T, typename Range2T >
         inline SequenceSequenceT& ifind_all(
             SequenceSequenceT& Result,
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+            Range1T&& Input,
+#else
             Range1T& Input,
+#endif
             const Range2T& Search,
             const std::locale& Loc=std::locale() )
         {
@@ -139,7 +147,11 @@ namespace boost {
         template< typename SequenceSequenceT, typename RangeT, typename PredicateT >
         inline SequenceSequenceT& split(
             SequenceSequenceT& Result,
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+            RangeT&& Input,
+#else
             RangeT& Input,
+#endif
             PredicateT Pred,
             token_compress_mode_type eCompress=token_compress_off )
         {

--- a/string/test/split_test.cpp
+++ b/string/test/split_test.cpp
@@ -85,7 +85,7 @@ void iterator_test()
     deep_compare( tokens, vtokens );
 
 #if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
-    // If using a compiler that supports forwarding references, we should be able to use lvalues, too
+    // If using a compiler that supports forwarding references, we should be able to use rvalues, too
     find_all(
         tokens,
         string("xx-abc--xx-abb"),
@@ -169,7 +169,7 @@ void iterator_test()
     BOOST_CHECK( tokens[0]==string("") );
 
 #if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
-    // If using a compiler that supports forwarding references, we should be able to use lvalues, too
+    // If using a compiler that supports forwarding references, we should be able to use rvalues, too
     split(
         tokens,
         string("Xx-abc--xX-abb-xx"),

--- a/string/test/split_test.cpp
+++ b/string/test/split_test.cpp
@@ -7,6 +7,8 @@
 
 //  See http://www.boost.org for updates, documentation, and revision history.
 
+#include <boost/algorithm/string/config.hpp>
+
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
 // equals predicate is used for result comparison
@@ -82,6 +84,28 @@ void iterator_test()
         string("xx") );
     deep_compare( tokens, vtokens );
 
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+    // If using a compiler that supports forwarding references, we should be able to use lvalues, too
+    find_all(
+        tokens,
+        string("xx-abc--xx-abb"),
+        "xx" );
+
+    BOOST_REQUIRE( tokens.size()==2 );
+    BOOST_CHECK( tokens[0]==string("xx") );
+    BOOST_CHECK( tokens[1]==string("xx") );
+
+    ifind_all(
+        tokens,
+        string("Xx-abc--xX-abb-xx"),
+        "xx" );
+
+    BOOST_REQUIRE( tokens.size()==3 );
+    BOOST_CHECK( tokens[0]==string("Xx") );
+    BOOST_CHECK( tokens[1]==string("xX") );
+    BOOST_CHECK( tokens[2]==string("xx") );
+#endif
+
     // split tests
     split(
         tokens,
@@ -143,6 +167,21 @@ void iterator_test()
 
     BOOST_REQUIRE( tokens.size()==1 );
     BOOST_CHECK( tokens[0]==string("") );
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+    // If using a compiler that supports forwarding references, we should be able to use lvalues, too
+    split(
+        tokens,
+        string("Xx-abc--xX-abb-xx"),
+        is_any_of("xX"),
+        token_compress_on );
+
+    BOOST_REQUIRE( tokens.size()==4 );
+    BOOST_CHECK( tokens[0]==string("") );
+    BOOST_CHECK( tokens[1]==string("-abc--") );
+    BOOST_CHECK( tokens[2]==string("-abb-") );
+    BOOST_CHECK( tokens[3]==string("") );
+#endif
 
 
     find_iterator<string::iterator> fiter=make_find_iterator(str1, first_finder("xx"));


### PR DESCRIPTION
On compilers that support C++11, this allows both lvalues and rvalues to be used as inputs to the `split()`, `find_all()`, and `ifind_all()` functions.

For example, given a function `get_string()` that returns a `std::string`, this allows you to write:
```cpp
boost::split(result, get_string(), boost::is_any_of(" "));
```

I'm somewhat surprised that this hasn't been done before, so if I'm missing something, then do let me know. I've hardly done a comprehensive investigation on where else these changes could be made in `boost::algorithm`, so I'm also happy to expand this PR if necessary.