### PR TITLE
Modify docs to get more algorithms in the ToC

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -22,6 +22,7 @@ doxygen autodoc
                ../../../boost/algorithm/searching/*.hpp
                ../../../boost/algorithm/cxx11/*.hpp
                ../../../boost/algorithm/cxx14/*.hpp
+               ../../../boost/algorithm/cxx17/*.hpp
         ]
     : 
        <doxygen:param>"PREDEFINED=\"BOOST_ALGORITHM_DOXYGEN=1\""
@@ -40,8 +41,8 @@ boostbook standalone
     <xsl:param>"boost.doxygen.reftitle=Boost.Algorithms C++ Reference"
     <xsl:param>chapter.autolabel=0
     <xsl:param>chunk.section.depth=8
-    <xsl:param>toc.section.depth=2
-    <xsl:param>toc.max.depth=2
+    <xsl:param>toc.section.depth=3
+    <xsl:param>toc.max.depth=3
     <xsl:param>generate.section.toc.level=1
   ;
 

--- a/doc/algorithm.qbk
+++ b/doc/algorithm.qbk
@@ -46,7 +46,11 @@ Thanks to all the people who have reviewed this library and made suggestions for
 [include knuth_morris_pratt.qbk]
 [endsect]
 
+
 [section:CXX11 C++11 Algorithms]
+
+[section:CXX11_inner_algorithms]
+
 [include all_of.qbk]
 [include any_of.qbk]
 [include none_of.qbk]
@@ -55,24 +59,204 @@ Thanks to all the people who have reviewed this library and made suggestions for
 [include is_partitioned.qbk]
 [include is_permutation.qbk]
 [include partition_point.qbk]
-[endsect]
+
+[section:partition_copy partition_copy ]
+[*[^[link header.boost.algorithm.cxx11.partition_copy_hpp            partition_copy]              ] ]
+Copy a subset of a sequence to a new sequence
+[endsect:partition_copy]
+
+[section:copy_if        copy_if        ]
+[*[^[link header.boost.algorithm.cxx11.copy_if_hpp                   copy_if]                     ] ]
+Copy a subset of a sequence to a new sequence
+[endsect:copy_if]
+
+[section:copy_n         copy_n         ]
+[*[^[link header.boost.algorithm.cxx11.copy_n_hpp                    copy_n]                      ] ]
+Copy n items from one sequence to another
+[endsect:copy_n]
+
+[section:iota           iota           ]
+[*[^[link header.boost.algorithm.cxx11.iota_hpp                      iota]                        ] ]
+Generate an increasing series
+[endsect:iota]
+
+[endsect:CXX11_inner_algorithms]
+
+[endsect:CXX11]
+
 
 [section:CXX14 C++14 Algorithms]
+
+[section:CXX14_inner_algorithms]
+
 [include equal.qbk]
 [include mismatch.qbk]
-[endsect]
+
+[endsect:CXX14_inner_algorithms]
+
+[endsect:CXX14]
+
+
+[section:CXX17 C++17 Algorithms]
+
+[section:CXX17_inner_algorithms]
+
+[section:for_each_n for_each_n]
+[*[^[link boost.algorithm.for_each_n                                 for_each_n]                  ] ]
+Apply a functor to the elements of a sequence
+[endsect:for_each_n]
+
+[endsect:CXX17_inner_algorithms]
+
+[endsect:CXX17]
+
 
 [section:Misc Other Algorithms]
-[include clamp-hpp.qbk]
-[include find_not.qbk]
-[include find_backward.qbk]
-[include gather.qbk]
-[include hex.qbk]
-[include is_palindrome.qbk]
-[include is_partitioned_until.qbk]
-[include apply_permutation.qbk]
-[endsect]
 
+[section:misc_inner_algorithms]
+
+[section:none_of_equal             none_of_equal             ]
+[*[^[link header.boost.algorithm.cxx11.none_of_hpp                   none_of_equal]               ] ]
+Whether none of a range's elements matches a value
+[endsect:none_of_equal]
+
+[section:one_of_equal              one_of_equal              ]
+[*[^[link header.boost.algorithm.cxx11.one_of_hpp                    one_of_equal]                ] ]
+Whether only one of a range's elements matches a value
+[endsect:one_of_equal]
+
+[section:is_decreasing             is_decreasing             ]
+[*[^[link header.boost.algorithm.cxx11.is_sorted_hpp                 is_decreasing]               ] ]
+Whether an entire sequence is decreasing; i.e, each item is less than or equal to the previous one
+[endsect:is_decreasing]
+
+[section:is_increasing             is_increasing             ]
+[*[^[link header.boost.algorithm.cxx11.is_sorted_hpp                 is_increasing]               ] ]
+Whether an entire sequence is increasing; i.e, each item is greater than or equal to the previous one
+[endsect:is_increasing]
+
+[section:is_strictly_decreasing    is_strictly_decreasing    ]
+[*[^[link header.boost.algorithm.cxx11.is_sorted_hpp                 is_strictly_decreasing]      ] ]
+Whether an entire sequence is strictly decreasing; i.e, each item is less than the previous one
+[endsect:is_strictly_decreasing]
+
+[section:is_strictly_increasing    is_strictly_increasing    ]
+[*[^[link header.boost.algorithm.cxx11.is_sorted_hpp                 is_strictly_increasing]      ] ]
+Whether an entire sequence is strictly increasing; i.e, each item is greater than the previous one
+[endsect:is_strictly_increasing]
+
+[include clamp-hpp.qbk]
+
+[section:clamp_range               clamp_range               ]
+[*[^[link header.boost.algorithm.clamp_hpp                           clamp_range]                 ] ]
+Perform [^clamp] on the elements of a range and write the results into an output iterator
+[endsect:clamp_range]
+
+[include find_not.qbk]
+
+[include find_backward.qbk]
+
+[section:find_not_backward         find_not_backward         ]
+[*[^[link header.boost.algorithm.find_backward_hpp                   find_not_backward]           ] ]
+Find the last element in a sequence that does not equal a value.
+See [link the_boost_algorithm_library.Misc.misc_inner_algorithms.find_backward find_backward].
+[endsect:find_not_backward]
+
+[section:find_if_backward          find_if_backward          ]
+[*[^[link header.boost.algorithm.find_backward_hpp                   find_if_backward]            ] ]
+Find the last element in a sequence that satisfies a predicate.
+See [link the_boost_algorithm_library.Misc.misc_inner_algorithms.find_backward find_backward].
+[endsect:find_if_backward]
+
+[section:find_if_not               find_if_not               ]
+[*[^[link header.boost.algorithm.cxx11.find_if_not_hpp               find_if_not]                 ] ]
+Find the first element in a sequence that does not satisfy a predicate.
+See [link the_boost_algorithm_library.Misc.misc_inner_algorithms.find_not find_not].
+[endsect:find_if_not]
+
+[section:find_if_not_backward      find_if_not_backward      ]
+[*[^[link header.boost.algorithm.find_backward_hpp                   find_if_not_backward]        ] ]
+Find the last element in a sequence that does not satisfy a predicate.
+See [link the_boost_algorithm_library.Misc.misc_inner_algorithms.find_backward find_backward].
+[endsect:find_if_not_backward]
+
+[include gather.qbk]
+
+[include hex.qbk]
+
+[section:unhex                     unhex                     ]
+[*[^[link header.boost.algorithm.hex_hpp                             unhex]                       ] ]
+Convert a sequence of hexadecimal characters into a sequence of integers or characters
+[endsect:unhex]
+
+[section:hex_lower                 hex_lower                 ]
+[*[^[link header.boost.algorithm.hex_hpp                             hex_lower]                   ] ]
+Convert a sequence of integral types into a lower case hexadecimal sequence of characters
+[endsect:hex_lower]
+
+[include is_palindrome.qbk]
+
+[include is_partitioned_until.qbk]
+
+[section:apply_reverse_permutation apply_reverse_permutation ]
+See below
+[endsect:apply_reverse_permutation]
+
+[include apply_permutation.qbk]
+
+[section:copy_until                copy_until                ]
+[*[^[link header.boost.algorithm.cxx11.copy_if_hpp                   copy_until]                  ] ]
+Copy all the elements at the start of the input range that do not satisfy the predicate to the output range
+[endsect:copy_until]
+
+[section:copy_while                copy_while                ]
+[*[^[link header.boost.algorithm.cxx11.copy_if_hpp                   copy_while]                  ] ]
+Copy all the elements at the start of the input range that satisfy the predicate to the output range
+[endsect:copy_while]
+
+[section:iota_n                    iota_n                    ]
+[*[^[link boost.algorithm.iota_n                                     iota_n]                      ] ]
+Write a sequence of n increasing values to an output iterator
+[endsect:iota_n]
+
+[section:power                     power                     ]
+[*[^[link header.boost.algorithm.algorithm_hpp                       power]                       ] ]
+Raise a value to an integral power ([^constexpr] since C++14)
+[endsect:power]
+
+[endsect:misc_inner_algorithms]
+
+[endsect:Misc]
+
+
+[section:not_yet_documented_cxx17_algos Not-yet-documented C++17 Algorithms]
+
+* [*[^[link header.boost.algorithm.cxx17.exclusive_scan_hpp            exclusive_scan]              ] ]
+* [*[^[link header.boost.algorithm.cxx17.inclusive_scan_hpp            inclusive_scan]              ] ]
+* [*[^[link header.boost.algorithm.cxx17.reduce_hpp                    reduce]                      ] ]
+* [*[^[link header.boost.algorithm.cxx17.transform_exclusive_scan_hpp  transform_exclusive_scan]    ] ]
+* [*[^[link header.boost.algorithm.cxx17.transform_inclusive_scan_hpp  transform_inclusive_scan]    ] ]
+* [*[^[link header.boost.algorithm.cxx17.transform_reduce_hpp          transform_reduce]            ] ]
+
+[endsect:not_yet_documented_cxx17_algos]
+
+
+[section:not_yet_documented_other_algos Not-yet-documented Other Algorithms]
+
+* [*[^[link header.boost.algorithm.minmax_hpp                          minmax]                      ] ]
+* [*[^[link header.boost.algorithm.minmax_element_hpp                  first_max_element]           ] ]
+* [*[^[link header.boost.algorithm.minmax_element_hpp                  first_min_element]           ] ]
+* [*[^[link header.boost.algorithm.minmax_element_hpp                  first_min_first_max_element] ] ]
+* [*[^[link header.boost.algorithm.minmax_element_hpp                  first_min_last_max_element]  ] ]
+* [*[^[link header.boost.algorithm.minmax_element_hpp                  last_max_element]            ] ]
+* [*[^[link header.boost.algorithm.minmax_element_hpp                  last_min_element]            ] ]
+* [*[^[link header.boost.algorithm.minmax_element_hpp                  last_min_first_max_element]  ] ]
+* [*[^[link header.boost.algorithm.minmax_element_hpp                  last_min_last_max_element]   ] ]
+* [*[^[link header.boost.algorithm.minmax_element_hpp                  minmax_element]              ] ]
+* [*[^[link header.boost.algorithm.sort_subrange_hpp                   partition_subrange]          ] ]
+* [*[^[link header.boost.algorithm.sort_subrange_hpp                   sort_subrange]               ] ]
+
+[endsect:not_yet_documented_other_algos]
 
 
 [xinclude autodoc.xml]

--- a/doc/apply_permutation.qbk
+++ b/doc/apply_permutation.qbk
@@ -9,7 +9,7 @@ Distributed under the Boost Software License, Version 1.0.
 (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 ]
 
-The header file 'apply_permutation.hpp' contains two algorithms, apply_permutation and apply_reverse_permutation. Also there are range-based versions. 
+The header file [^[link header.boost.algorithm.apply_permutation_hpp apply_permutation.hpp]] contains two algorithms, `apply_permutation` and `apply_reverse_permutation`. There are also range-based versions.
 The algorithms transform the item sequence according to index sequence order.
 
 The routine `apply_permutation` takes a item sequence and a order sequence. It reshuffles item sequence according to order sequence. Every value in order sequence means where the item comes from. Order sequence needs to be exactly a permutation of the sequence [0, 1, ... , N], where N is the biggest index in the item sequence (zero-indexed).


### PR DESCRIPTION
Here's a PR for #55.

I found it tricky to manipulate the sections to get the entries I wanted in the ToC, such that their links help navigation. I've managed to get something sensible working here. However I should highlight that these changes have:
 * put the sections of text _inline_ within one page per parent category (such as "C++11 Algorithms")
 * nested each of the groups of algorithms within another untitled section (because otherwise, I couldn't get them all to appear on the same page)

And of course those changes may have broken some previous URLs into the docs.

What do you think? I think this is broadly a change in the right direction but I'd welcome any suggestions you have about better ways to achieve the same goals.