### PR TITLE
Changes for Embarcadero C++ clang-based compilers, targeting Boost 1.74. Change __BORLANDC__ to BOOST_BORLANDC, which is defined in Boost conf…

### DIFF
--- a/include/boost/algorithm/string/compare.hpp
+++ b/include/boost/algorithm/string/compare.hpp
@@ -65,7 +65,7 @@ namespace boost {
             template< typename T1, typename T2 >
                 bool operator()( const T1& Arg1, const T2& Arg2 ) const
             {
-                #if defined(__BORLANDC__) && (__BORLANDC__ >= 0x560) && (__BORLANDC__ <= 0x564) && !defined(_USE_OLD_RW_STL)
+                #if defined(BOOST_BORLANDC) && (BOOST_BORLANDC >= 0x560) && (BOOST_BORLANDC <= 0x564) && !defined(_USE_OLD_RW_STL)
                     return std::toupper(Arg1)==std::toupper(Arg2);
                 #else
                     return std::toupper<T1>(Arg1,m_Loc)==std::toupper<T2>(Arg2,m_Loc);
@@ -118,7 +118,7 @@ namespace boost {
             template< typename T1, typename T2 >
                 bool operator()( const T1& Arg1, const T2& Arg2 ) const
             {
-                #if defined(__BORLANDC__) && (__BORLANDC__ >= 0x560) && (__BORLANDC__ <= 0x564) && !defined(_USE_OLD_RW_STL)
+                #if defined(BOOST_BORLANDC) && (BOOST_BORLANDC >= 0x560) && (BOOST_BORLANDC <= 0x564) && !defined(_USE_OLD_RW_STL)
                     return std::toupper(Arg1)<std::toupper(Arg2);
                 #else
                     return std::toupper<T1>(Arg1,m_Loc)<std::toupper<T2>(Arg2,m_Loc);
@@ -171,7 +171,7 @@ namespace boost {
             template< typename T1, typename T2 >
                 bool operator()( const T1& Arg1, const T2& Arg2 ) const
             {
-                #if defined(__BORLANDC__) && (__BORLANDC__ >= 0x560) && (__BORLANDC__ <= 0x564) && !defined(_USE_OLD_RW_STL)
+                #if defined(BOOST_BORLANDC) && (BOOST_BORLANDC >= 0x560) && (BOOST_BORLANDC <= 0x564) && !defined(_USE_OLD_RW_STL)
                     return std::toupper(Arg1)<=std::toupper(Arg2);
                 #else
                     return std::toupper<T1>(Arg1,m_Loc)<=std::toupper<T2>(Arg2,m_Loc);

--- a/include/boost/algorithm/string/detail/case_conv.hpp
+++ b/include/boost/algorithm/string/detail/case_conv.hpp
@@ -40,7 +40,7 @@ namespace boost {
                 // Operation
                 CharT operator ()( CharT Ch ) const
                 {
-                    #if defined(__BORLANDC__) && (__BORLANDC__ >= 0x560) && (__BORLANDC__ <= 0x564) && !defined(_USE_OLD_RW_STL)
+                    #if defined(BOOST_BORLANDC) && (BOOST_BORLANDC >= 0x560) && (BOOST_BORLANDC <= 0x564) && !defined(_USE_OLD_RW_STL)
                         return std::tolower( static_cast<typename boost::make_unsigned <CharT>::type> ( Ch ));
                     #else
                         return std::tolower<CharT>( Ch, *m_Loc );
@@ -62,7 +62,7 @@ namespace boost {
                 // Operation
                 CharT operator ()( CharT Ch ) const
                 {
-                    #if defined(__BORLANDC__) && (__BORLANDC__ >= 0x560) && (__BORLANDC__ <= 0x564) && !defined(_USE_OLD_RW_STL)
+                    #if defined(BOOST_BORLANDC) && (BOOST_BORLANDC >= 0x560) && (BOOST_BORLANDC <= 0x564) && !defined(_USE_OLD_RW_STL)
                         return std::toupper( static_cast<typename boost::make_unsigned <CharT>::type> ( Ch ));
                     #else
                         return std::toupper<CharT>( Ch, *m_Loc );

--- a/include/boost/algorithm/string/detail/classification.hpp
+++ b/include/boost/algorithm/string/detail/classification.hpp
@@ -45,7 +45,7 @@ namespace boost {
                     return std::use_facet< std::ctype<CharT> >(m_Locale).is( m_Type, Ch );
                 }
 
-                #if defined(__BORLANDC__) && (__BORLANDC__ >= 0x560) && (__BORLANDC__ <= 0x582) && !defined(_USE_OLD_RW_STL)
+                #if defined(BOOST_BORLANDC) && (BOOST_BORLANDC >= 0x560) && (BOOST_BORLANDC <= 0x582) && !defined(_USE_OLD_RW_STL)
                     template<>
                     bool operator()( char const Ch ) const
                     {

--- a/include/boost/algorithm/string/detail/formatter.hpp
+++ b/include/boost/algorithm/string/detail/formatter.hpp
@@ -42,7 +42,7 @@ namespace boost {
                     m_Format(::boost::begin(Format), ::boost::end(Format)) {}
 
                 // Operation
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
                 template<typename Range2T>
                 result_type& operator()(const Range2T&)
                 {


### PR DESCRIPTION
…ig for the Embarcadero non-clang-based compilers.