### PR TITLE
Avoid using deprecated header boost/detail/iterator.hpp

### DIFF
--- a/include/boost/algorithm/string/detail/finder.hpp
+++ b/include/boost/algorithm/string/detail/finder.hpp
@@ -13,7 +13,7 @@
 
 #include <boost/algorithm/string/config.hpp>
 #include <boost/algorithm/string/constants.hpp>
-#include <boost/detail/iterator.hpp>
+#include <iterator>
 
 #include <boost/range/iterator_range_core.hpp>
 #include <boost/range/begin.hpp>
@@ -127,8 +127,8 @@ namespace boost {
                     if( boost::empty(m_Search) )
                         return result_type( End, End );
 
-                    typedef BOOST_STRING_TYPENAME boost::detail::
-                        iterator_traits<ForwardIteratorT>::iterator_category category;
+                    typedef BOOST_STRING_TYPENAME
+                        std::iterator_traits<ForwardIteratorT>::iterator_category category;
 
                     return findit( Begin, End, category() );
                 }
@@ -375,8 +375,8 @@ namespace boost {
                 ForwardIteratorT End,
                 unsigned int N )
             {
-                typedef BOOST_STRING_TYPENAME boost::detail::
-                    iterator_traits<ForwardIteratorT>::iterator_category category;
+                typedef BOOST_STRING_TYPENAME
+                    std::iterator_traits<ForwardIteratorT>::iterator_category category;
 
                 return ::boost::algorithm::detail::find_head_impl( Begin, End, N, category() );
             }
@@ -448,8 +448,8 @@ namespace boost {
                 ForwardIteratorT End,
                 unsigned int N )
             {
-                typedef BOOST_STRING_TYPENAME boost::detail::
-                    iterator_traits<ForwardIteratorT>::iterator_category category;
+                typedef BOOST_STRING_TYPENAME
+                    std::iterator_traits<ForwardIteratorT>::iterator_category category;
 
                 return ::boost::algorithm::detail::find_tail_impl( Begin, End, N, category() );
             }

--- a/include/boost/algorithm/string/detail/trim.hpp
+++ b/include/boost/algorithm/string/detail/trim.hpp
@@ -12,7 +12,7 @@
 #define BOOST_STRING_TRIM_DETAIL_HPP
 
 #include <boost/algorithm/string/config.hpp>
-#include <boost/detail/iterator.hpp>
+#include <iterator>
 
 namespace boost {
     namespace algorithm {
@@ -80,8 +80,8 @@ namespace boost {
                 ForwardIteratorT InEnd, 
                 PredicateT IsSpace )
             {
-                typedef BOOST_STRING_TYPENAME boost::detail::
-                    iterator_traits<ForwardIteratorT>::iterator_category category;
+                typedef BOOST_STRING_TYPENAME
+                    std::iterator_traits<ForwardIteratorT>::iterator_category category;
 
                 return ::boost::algorithm::detail::trim_end_iter_select( InBegin, InEnd, IsSpace, category() );
             }

--- a/include/boost/algorithm/string/predicate.hpp
+++ b/include/boost/algorithm/string/predicate.hpp
@@ -11,6 +11,7 @@
 #ifndef BOOST_STRING_PREDICATE_HPP
 #define BOOST_STRING_PREDICATE_HPP
 
+#include <iterator>
 #include <boost/algorithm/string/config.hpp>
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
@@ -144,10 +145,10 @@ namespace boost {
             iterator_range<BOOST_STRING_TYPENAME range_const_iterator<Range1T>::type> lit_input(::boost::as_literal(Input));
             iterator_range<BOOST_STRING_TYPENAME range_const_iterator<Range2T>::type> lit_test(::boost::as_literal(Test));
 
-            typedef BOOST_STRING_TYPENAME 
+            typedef BOOST_STRING_TYPENAME
                 range_const_iterator<Range1T>::type Iterator1T;
-            typedef BOOST_STRING_TYPENAME boost::detail::
-                iterator_traits<Iterator1T>::iterator_category category;
+            typedef BOOST_STRING_TYPENAME
+                std::iterator_traits<Iterator1T>::iterator_category category;
 
             return detail::
                 ends_with_iter_select( 


### PR DESCRIPTION
This header is deprecated in favor of `<iterator>` and will be removed in a future release. This silences deprecation warnings.