### PR TITLE
Remove a few leftover uses of boost/detail/iterator.hpp

### DIFF
--- a/include/boost/algorithm/string/find_format.hpp
+++ b/include/boost/algorithm/string/find_format.hpp
@@ -12,7 +12,6 @@
 #define BOOST_STRING_FIND_FORMAT_HPP
 
 #include <deque>
-#include <boost/detail/iterator.hpp>
 #include <boost/range/iterator_range_core.hpp>
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
@@ -40,7 +39,7 @@ namespace boost {
             this substring and replace it in the input.
             The result is a modified copy of the input. It is returned as a sequence 
             or copied to the output iterator.
-    
+
             \param Output An output iterator to which the result will be copied
             \param Input An input sequence
             \param Finder A Finder object used to search for a match to be replaced

--- a/include/boost/algorithm/string/formatter.hpp
+++ b/include/boost/algorithm/string/formatter.hpp
@@ -11,7 +11,6 @@
 #ifndef BOOST_STRING_FORMATTER_HPP
 #define BOOST_STRING_FORMATTER_HPP
 
-#include <boost/detail/iterator.hpp>
 #include <boost/range/value_type.hpp>
 #include <boost/range/iterator_range_core.hpp>
 #include <boost/range/as_literal.hpp>

--- a/string/example/rle_example.cpp
+++ b/string/example/rle_example.cpp
@@ -16,7 +16,7 @@
 #include <string>
 #include <iostream>
 #include <limits>
-#include <boost/detail/iterator.hpp>
+#include <iterator>
 #include <boost/algorithm/string/find_format.hpp>
 #include <boost/algorithm/string/finder.hpp>
 
@@ -46,7 +46,7 @@ struct find_compressF
         ForwardIteratorT End ) const
     {
         typedef ForwardIteratorT input_iterator_type;
-        typedef typename boost::detail::iterator_traits<input_iterator_type>::value_type value_type;
+        typedef typename std::iterator_traits<input_iterator_type>::value_type value_type;
         typedef iterator_range<input_iterator_type> result_type;
 
         // begin of the matching segment
@@ -144,7 +144,7 @@ struct find_decompressF
         ForwardIteratorT End ) const
     {
         typedef ForwardIteratorT input_iterator_type;
-        typedef typename boost::detail::iterator_traits<input_iterator_type>::value_type value_type;
+        typedef typename std::iterator_traits<input_iterator_type>::value_type value_type;
         typedef iterator_range<input_iterator_type> result_type;
 
         for(input_iterator_type It=Begin; It!=End; It++)
@@ -153,12 +153,12 @@ struct find_decompressF
             {
                 // Repeat mark found, extract body
                 input_iterator_type It2=It++; 
-                
+
                 if ( It==End ) break;
                     It++; 
                 if ( It==End ) break;
                     It++;
-                
+
                 return result_type( It2, It );
             }
         }


### PR DESCRIPTION
This is in continuation of https://github.com/boostorg/algorithm/pull/71.

These instances were not detected by tests.
