### PR TITLE
Add missing include

### DIFF
--- a/include/boost/algorithm/string/detail/find_format_all.hpp
+++ b/include/boost/algorithm/string/detail/find_format_all.hpp
@@ -18,6 +18,8 @@
 #include <boost/algorithm/string/detail/find_format_store.hpp>
 #include <boost/algorithm/string/detail/replace_storage.hpp>
 
+#include <deque>
+
 namespace boost {
     namespace algorithm {
         namespace detail {


### PR DESCRIPTION
This patch allows the header to be built standalone, as part of clang C++ modules builds.