### PR TITLE
Add missing includes

### DIFF
--- a/include/boost/algorithm/string/detail/case_conv.hpp
+++ b/include/boost/algorithm/string/detail/case_conv.hpp
@@ -15,6 +15,9 @@
 #include <locale>
 #include <functional>
 
+#include <boost/iterator/transform_iterator.hpp>
+#include <boost/range/begin.hpp>
+#include <boost/range/end.hpp>
 #include <boost/type_traits/make_unsigned.hpp>
 
 namespace boost {


### PR DESCRIPTION
This patch allows the header to be built standalone, as part of clang C++ modules builds.