### PR TITLE
Add missing include

### DIFF
--- a/include/boost/algorithm/string/detail/classification.hpp
+++ b/include/boost/algorithm/string/detail/classification.hpp
@@ -13,6 +13,7 @@
 
 #include <boost/algorithm/string/config.hpp>
 #include <algorithm>
+#include <cstring>
 #include <functional>
 #include <locale>
 


### PR DESCRIPTION
This patch allows the header to be built standalone, as part of clang C++ modules builds.