### PR TITLE
Ill-formed include guard fix

### DIFF
--- a/include/boost/algorithm/cxx17/inclusive_scan.hpp
+++ b/include/boost/algorithm/cxx17/inclusive_scan.hpp
@@ -5,12 +5,12 @@
    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 */
 
-/// \file  transform_reduce.hpp
-/// \brief Combine the (transformed) elements of a sequence (or two) into a single value.
+/// \file  inclusive_scan.hpp
+/// \brief Computes an inclusive prefix sum operation
 /// \author Marshall Clow
 
-#ifndef BOOST_ALGORITHM_TRANSFORM_REDUCE_HPP
-#define BOOST_ALGORITHM_TRANSFORM_REDUCE_HPP
+#ifndef BOOST_ALGORITHM_INCLUSIVE_SCAN_HPP
+#define BOOST_ALGORITHM_INCLUSIVE_SCAN_HPP
 
 #include <functional>     // for std::plus
 #include <iterator>       // for std::iterator_traits
@@ -58,4 +58,4 @@ OutputIterator inclusive_scan(InputIterator first, InputIterator last,
 
 }} // namespace boost and algorithm
 
-#endif // BOOST_ALGORITHM_TRANSFORM_REDUCE_HPP
+#endif // BOOST_ALGORITHM_INCLUSIVE_SCAN_HPP


### PR DESCRIPTION
I've discovered that if one includes transform_reduce.hpp and inclusive_scan.hpp they cannot use functions from the last included header.

The reason is ill-formed include guard in inclusive_scan.hpp, originally copy-pasted from transform_reduce.hpp. I've fixed it.