### PR TITLE
Add is_clamped.hpp, is_clamped_test.cpp

### DIFF
--- a/include/boost/algorithm/is_clamped.hpp
+++ b/include/boost/algorithm/is_clamped.hpp
@@ -1,5 +1,5 @@
 /* 
-   Copyright (c) Marshall Clow 2008-2012.
+   Copyright (c) Ivan Matek, Marshall Clow 2021.
 
    Distributed under the Boost Software License, Version 1.0. (See accompanying
    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/include/boost/algorithm/is_clamped.hpp
+++ b/include/boost/algorithm/is_clamped.hpp
@@ -8,7 +8,7 @@
 
 /// \file is_clamped.hpp
 /// \brief IsClamped algorithm
-/// \author TODO
+/// \authors Ivan Matek, Marshall Clow
 ///
 
 #ifndef BOOST_ALGORITHM_IS_CLAMPED_HPP

--- a/include/boost/algorithm/is_clamped.hpp
+++ b/include/boost/algorithm/is_clamped.hpp
@@ -1,0 +1,73 @@
+/* 
+   Copyright (c) Marshall Clow 2008-2012.
+
+   Distributed under the Boost Software License, Version 1.0. (See accompanying
+   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+  
+*/
+
+/// \file is_clamped.hpp
+/// \brief IsClamped algorithm
+/// \author TODO
+///
+
+#ifndef BOOST_ALGORITHM_IS_CLAMPED_HPP
+#define BOOST_ALGORITHM_IS_CLAMPED_HPP
+
+#include <functional>       //  For std::less
+#include <iterator>         //  For std::iterator_traits
+#include <cassert>
+
+#include <boost/mpl/identity.hpp>      // for identity
+
+namespace boost { namespace algorithm {
+
+/// \fn is_clamped ( T const& val,
+///               typename boost::mpl::identity<T>::type const & lo,
+///               typename boost::mpl::identity<T>::type const & hi, Pred p )
+/// \returns true if value "val" is in the range [ lo, hi ]
+///     using the comparison predicate p.
+///     If p ( val, lo ) return false.
+///     If p ( hi, val ) return false.
+///     Otherwise, returns true.
+///
+/// \param val   The value to be checked
+/// \param lo    The lower bound of the range
+/// \param hi    The upper bound of the range
+/// \param p     A predicate to use to compare the values.
+///                 p ( a, b ) returns a boolean.
+///
+  template <typename T, typename Pred>
+  BOOST_CXX14_CONSTEXPR bool is_clamped(
+      T const& val, typename boost::mpl::identity<T>::type const& lo,
+      typename boost::mpl::identity<T>::type const& hi, Pred p) {
+    //    assert ( !p ( hi, lo ));    // Can't assert p ( lo, hi ) b/c they
+    //    might be equal
+    return p(val, lo) ? false : p(hi, val) ? false : true;
+  }
+  
+/// \fn is_clamped ( T const& val,
+///               typename boost::mpl::identity<T>::type const & lo,
+///               typename boost::mpl::identity<T>::type const & hi)
+/// \returns true if value "val" is in the range [ lo, hi ]
+///     using operator < for comparison.
+///     If the value is less than lo, return false.
+///     If the value is greater than "hi", return false.
+///     Otherwise, returns true.
+///
+/// \param val   The value to be checked
+/// \param lo    The lower bound of the range
+/// \param hi    The upper bound of the range
+///
+  
+  template<typename T> 
+  BOOST_CXX14_CONSTEXPR bool is_clamped ( const T& val, 
+    typename boost::mpl::identity<T>::type const & lo, 
+    typename boost::mpl::identity<T>::type const & hi )
+  {
+    return boost::algorithm::is_clamped ( val, lo, hi, std::less<T>());
+  } 
+
+}}
+
+#endif // BOOST_ALGORITHM_CLAMP_HPP

--- a/include/boost/algorithm/is_clamped.hpp
+++ b/include/boost/algorithm/is_clamped.hpp
@@ -17,7 +17,7 @@
 #include <functional>       //  For std::less
 #include <cassert>
 
-#include <boost/mpl/identity.hpp>      // for identity
+#include <boost/type_traits/type_identity.hpp> // for boost::type_identity
 
 namespace boost { namespace algorithm {
 
@@ -38,8 +38,8 @@ namespace boost { namespace algorithm {
 ///
   template <typename T, typename Pred>
   BOOST_CXX14_CONSTEXPR bool is_clamped(
-      T const& val, typename boost::mpl::identity<T>::type const& lo,
-      typename boost::mpl::identity<T>::type const& hi, Pred p) {
+      T const& val, typename boost::type_identity<T>::type const& lo,
+      typename boost::type_identity<T>::type const& hi, Pred p) {
     //    assert ( !p ( hi, lo ));    // Can't assert p ( lo, hi ) b/c they
     //    might be equal
     return p(val, lo) ? false : p(hi, val) ? false : true;
@@ -48,7 +48,7 @@ namespace boost { namespace algorithm {
 /// \fn is_clamped ( T const& val,
 ///               typename boost::mpl::identity<T>::type const & lo,
 ///               typename boost::mpl::identity<T>::type const & hi)
-/// \returns true if value val is in the range [ lo, hi ]
+/// \returns true if value "val" is in the range [ lo, hi ]
 ///     using operator < for comparison.
 ///     If the value is less than lo, return false.
 ///     If the value is greater than hi, return false.
@@ -60,9 +60,9 @@ namespace boost { namespace algorithm {
 ///
   
   template<typename T> 
-  BOOST_CXX14_CONSTEXPR bool is_clamped ( const T& val, 
-    typename boost::mpl::identity<T>::type const & lo, 
-    typename boost::mpl::identity<T>::type const & hi )
+  BOOST_CXX14_CONSTEXPR bool is_clamped ( const T& val,
+    typename boost::type_identity<T>::type const & lo,
+    typename boost::type_identity<T>::type const & hi )
   {
     return boost::algorithm::is_clamped ( val, lo, hi, std::less<T>());
   } 

--- a/include/boost/algorithm/is_clamped.hpp
+++ b/include/boost/algorithm/is_clamped.hpp
@@ -15,7 +15,6 @@
 #define BOOST_ALGORITHM_IS_CLAMPED_HPP
 
 #include <functional>       //  For std::less
-#include <iterator>         //  For std::iterator_traits
 #include <cassert>
 
 #include <boost/mpl/identity.hpp>      // for identity

--- a/include/boost/algorithm/is_clamped.hpp
+++ b/include/boost/algorithm/is_clamped.hpp
@@ -48,10 +48,10 @@ namespace boost { namespace algorithm {
 /// \fn is_clamped ( T const& val,
 ///               typename boost::mpl::identity<T>::type const & lo,
 ///               typename boost::mpl::identity<T>::type const & hi)
-/// \returns true if value "val" is in the range [ lo, hi ]
+/// \returns true if value val is in the range [ lo, hi ]
 ///     using operator < for comparison.
 ///     If the value is less than lo, return false.
-///     If the value is greater than "hi", return false.
+///     If the value is greater than hi, return false.
 ///     Otherwise, returns true.
 ///
 /// \param val   The value to be checked

--- a/include/boost/algorithm/is_clamped.hpp
+++ b/include/boost/algorithm/is_clamped.hpp
@@ -14,7 +14,7 @@
 #ifndef BOOST_ALGORITHM_IS_CLAMPED_HPP
 #define BOOST_ALGORITHM_IS_CLAMPED_HPP
 
-#include <functional>       //  For std::less
+#include <functional>       //  for std::less
 #include <cassert>
 
 #include <boost/type_traits/type_identity.hpp> // for boost::type_identity
@@ -22,8 +22,8 @@
 namespace boost { namespace algorithm {
 
 /// \fn is_clamped ( T const& val,
-///               typename boost::mpl::identity<T>::type const & lo,
-///               typename boost::mpl::identity<T>::type const & hi, Pred p )
+///               typename boost::type_identity<T>::type const & lo,
+///               typename boost::type_identity<T>::type const & hi, Pred p )
 /// \returns true if value "val" is in the range [ lo, hi ]
 ///     using the comparison predicate p.
 ///     If p ( val, lo ) return false.
@@ -46,8 +46,8 @@ namespace boost { namespace algorithm {
   }
   
 /// \fn is_clamped ( T const& val,
-///               typename boost::mpl::identity<T>::type const & lo,
-///               typename boost::mpl::identity<T>::type const & hi)
+///               typename boost::type_identity<T>::type const & lo,
+///               typename boost::type_identity<T>::type const & hi)
 /// \returns true if value "val" is in the range [ lo, hi ]
 ///     using operator < for comparison.
 ///     If the value is less than lo, return false.

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -29,6 +29,7 @@ alias unit_test_framework
 
 # Misc tests
      [ run clamp_test.cpp unit_test_framework         : : : : clamp_test ]
+     [ run is_clamped_test.cpp unit_test_framework    : : : : is_clamped_test ]
      [ run power_test.cpp unit_test_framework         : : : : power_test ]
      [ compile-fail power_fail1.cpp  : : : : ]
 

--- a/test/is_clamped_test.cpp
+++ b/test/is_clamped_test.cpp
@@ -3,11 +3,11 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/algorithm/clamp.hpp>
 #include <boost/algorithm/is_clamped.hpp>
+#include <boost/algorithm/clamp.hpp>
 #include <cmath>
 #include <cstdint>
-#ifdef __cpp_impl_three_way_comparison
+#ifdef __cpp_impl_three_way_comparison &&__has_include(<compare>)
 #include <compare>
 #endif
 #include <limits>
@@ -167,7 +167,7 @@ void test_constexpr() {
 }
 
 
-#ifdef __cpp_impl_three_way_comparison
+#ifdef __cpp_impl_three_way_comparison &&__has_include(<compare>)
 struct custom_with_spaceship {
   int v;
   auto operator<=>(const custom_with_spaceship&) const = default;
@@ -175,7 +175,7 @@ struct custom_with_spaceship {
 #endif
 
 void test_spaceship() {
-  #ifdef __cpp_impl_three_way_comparison
+  #ifdef __cpp_impl_three_way_comparison &&__has_include(<compare>)
   //  Inside the range, equal to the endpoints, and outside the endpoints.
   const custom_with_spaceship c0(0);
   const custom_with_spaceship c1(1);

--- a/test/is_clamped_test.cpp
+++ b/test/is_clamped_test.cpp
@@ -1,0 +1,224 @@
+﻿//  (C) Copyright TODO
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/algorithm/clamp.hpp>
+#include <boost/algorithm/is_clamped.hpp>
+#include <cmath>
+#include <cstdint>
+#ifdef __cpp_impl_three_way_comparison
+#include <compare>
+#endif
+#include <limits>
+#include <string>
+#include <tuple>
+
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+namespace ba = boost::algorithm;
+
+BOOST_CONSTEXPR bool intGreater(int lhs, int rhs) { return lhs > rhs; }
+
+class custom {
+ public:
+  custom(int x) : v(x) {}
+  custom(const custom &rhs) : v(rhs.v) {}
+
+  bool operator<(const custom &rhs) const { return v < rhs.v; }
+  bool operator==(const custom &rhs) const {
+    return v == rhs.v;
+  }  // need this for the test
+  int v;
+};
+
+static bool customLess(const custom &lhs, const custom &rhs) { return lhs.v < rhs.v; }
+
+void test_ints() {
+  //  Inside the range, equal to the endpoints, and outside the endpoints.
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( 3, 1, 6 ));
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( 1, 1, 6 ));
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( 6, 1, 6 ));
+  BOOST_CHECK_EQUAL ( false, ba::is_clamped ( 0, 1, 6 ));
+  BOOST_CHECK_EQUAL ( false, ba::is_clamped ( 7, 1, 6 ));
+
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( 3, 6, 1, intGreater ));
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( 1, 6, 1, intGreater ));
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( 6, 6, 1, intGreater ));
+  BOOST_CHECK_EQUAL ( false, ba::is_clamped ( 0, 6, 1, intGreater ));
+  BOOST_CHECK_EQUAL ( false, ba::is_clamped ( 7, 6, 1, intGreater ));
+
+  //  Negative numbers
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( -3, -6, -1 ));
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( -1, -6, -1 ));
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( -6, -6, -1 ));
+  BOOST_CHECK_EQUAL ( false, ba::is_clamped (  0, -6, -1 ));
+  BOOST_CHECK_EQUAL ( false, ba::is_clamped ( -7, -6, -1 ));
+
+  //  Mixed positive and negative numbers
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped (  1, -5, 5 ));
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( -5, -5, 5 ));
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped (  5, -5, 5 ));
+  BOOST_CHECK_EQUAL ( false, ba::is_clamped ( -6, -5, 5 ));
+  BOOST_CHECK_EQUAL ( false, ba::is_clamped (  6, -5, 5 ));
+
+  //  Unsigned
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( 5U, 1U, 6U ));
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( 1U, 1U, 6U ));
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( 6U, 1U, 6U ));
+  BOOST_CHECK_EQUAL ( false, ba::is_clamped ( 0U, 1U, 6U ));
+  BOOST_CHECK_EQUAL ( false, ba::is_clamped ( 8U, 1U, 6U ));
+
+  //  Mixed (1)
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( 5U, 1, 6 ));
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( 1U, 1, 6 ));
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( 6U, 1, 6 ));
+  BOOST_CHECK_EQUAL ( false, ba::is_clamped ( 0U, 1, 6 ));
+  BOOST_CHECK_EQUAL ( false, ba::is_clamped ( 8U, 1, 6 ));
+
+  //  Mixed (2)
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( 5U, 1, 6. ));
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( 1U, 1, 6. ));
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( 6U, 1, 6. ));
+  BOOST_CHECK_EQUAL ( false, ba::is_clamped ( 0U, 1, 6. ));
+  BOOST_CHECK_EQUAL ( false, ba::is_clamped ( 8U, 1, 6. ));
+
+  short foo = 50;
+  // float->short conversion does not round
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( foo, 50.999, 100 ));
+  BOOST_CHECK_EQUAL ( false, ba::is_clamped ( foo, 51.001, 100 ));
+}
+void test_floats() {
+  //  If floats are IEEE754 certain floats have exact representations.
+  if (std::numeric_limits<float>::is_iec559) {
+    const float lo = 0.125;
+    const float hi = 0.625;
+    BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( lo, lo, hi ));
+    BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( hi, lo, hi ));
+    BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( lo + 0.01, lo, hi ));
+    BOOST_CHECK_EQUAL ( false, ba::is_clamped ( lo - 0.01, lo, hi ));
+    BOOST_CHECK_EQUAL ( false, ba::is_clamped ( hi + 0.01, lo, hi ));
+    // If we have nextafterf we can be more precise.
+    #if __cplusplus >= 201103L
+    assert(lo < hi);
+    BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( hi, lo, hi ));
+    BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( std::nextafterf( lo, hi ), lo, hi ));
+    BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( std::nextafterf( hi, lo ), lo, hi ));
+    BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( (lo + hi) / 2, lo, hi ));
+    // 1.0 is just for direction of nextafterf, value of 1.0 is not significant.
+    BOOST_CHECK_EQUAL ( false, ba::is_clamped ( std::nextafterf( lo, lo - 1.0f ), lo, hi ));
+    BOOST_CHECK_EQUAL ( false, ba::is_clamped ( std::nextafterf( hi, hi + 1.0f ), lo, hi ));
+    #endif
+  }
+}
+
+void test_std_string() {
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( std::string("a3"), std::string("a1"), std::string("a6") ));
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( std::string("a1"), std::string("a1"), std::string("a6") ));
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( std::string("a6"), std::string("a1"), std::string("a6") ));
+  BOOST_CHECK_EQUAL ( false, ba::is_clamped ( std::string("a7"), std::string("a1"), std::string("a6") ));
+  BOOST_CHECK_EQUAL ( false, ba::is_clamped ( std::string("a0"), std::string("a1"), std::string("a6") ));
+}
+
+void test_custom() {
+  //  Inside the range, equal to the endpoints, and outside the endpoints.
+  const custom c0(0);
+  const custom c1(1);
+  const custom c3(3);
+  const custom c6(6);
+  const custom c7(7);
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( c3, c1, c6 ));
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( c1, c1, c6 ));
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( c6, c1, c6 ));
+  BOOST_CHECK_EQUAL ( false, ba::is_clamped ( c0, c1, c6 ));
+  BOOST_CHECK_EQUAL ( false, ba::is_clamped ( c7, c1, c6 ));
+
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( c3, c1, c6, customLess ));
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( c1, c1, c6, customLess ));
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped ( c6, c1, c6, customLess ));
+  BOOST_CHECK_EQUAL ( false, ba::is_clamped ( c0, c1, c6, customLess ));
+  BOOST_CHECK_EQUAL ( false, ba::is_clamped ( c7, c1, c6, customLess ));
+}
+
+void test_constexpr() {
+  #if __cplusplus >= 201402L
+  {
+    constexpr bool is_clamped = (ba::is_clamped ( 3, 1, 6 ));
+    BOOST_CHECK_EQUAL (true, is_clamped );
+  }
+  {
+    constexpr bool is_clamped = (ba::is_clamped ( 1, 1, 6 ));
+    BOOST_CHECK_EQUAL (true, is_clamped );
+  }
+  {
+    constexpr bool is_clamped = (ba::is_clamped ( 6, 1, 6 ));
+    BOOST_CHECK_EQUAL (true, is_clamped );
+  }
+  {
+    constexpr bool is_clamped = (ba::is_clamped ( 0, 1, 6 ));
+    BOOST_CHECK_EQUAL(false, is_clamped );
+  }
+  {
+    constexpr bool is_clamped = (ba::is_clamped ( 7, 1, 6 ));
+    BOOST_CHECK_EQUAL(false, is_clamped );
+  }
+  #endif
+}
+
+
+#ifdef __cpp_impl_three_way_comparison
+struct custom_with_spaceship {
+  int v;
+  auto operator<=>(const custom_with_spaceship&) const = default;
+};
+#endif
+
+void test_spaceship() {
+  #ifdef __cpp_impl_three_way_comparison
+  //  Inside the range, equal to the endpoints, and outside the endpoints.
+  const custom_with_spaceship c0(0);
+  const custom_with_spaceship c1(1);
+  const custom_with_spaceship c3(3);
+  const custom_with_spaceship c6(6);
+  const custom_with_spaceship c7(7);
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped (c3, c1, c6 ));
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped (c1, c1, c6 ));
+  BOOST_CHECK_EQUAL ( true,  ba::is_clamped (c6, c1, c6 ));
+  BOOST_CHECK_EQUAL ( false, ba::is_clamped (c0, c1, c6 ));
+  BOOST_CHECK_EQUAL ( false, ba::is_clamped (c7, c1, c6 ));
+  {
+    constexpr custom_with_spaceship c1(1);
+    constexpr custom_with_spaceship c3(3);
+    constexpr custom_with_spaceship c6(6);
+    constexpr bool clamped = ba::is_clamped (c3, c1, c6 );
+    BOOST_CHECK_EQUAL ( true, clamped );
+  }
+  #endif
+}
+
+BOOST_AUTO_TEST_CASE(test_main) {
+  test_ints();
+  test_floats();
+  test_std_string();
+  test_custom();
+  test_constexpr();
+  test_spaceship();
+}
+
+#if __cplusplus >= 201103L
+typedef std::tuple<std::uint8_t, std::int8_t, std::uint16_t, std::int16_t,
+                   std::int32_t, std::uint32_t, std::int64_t, std::uint64_t> test_types_tuple;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(test_extremes, T, test_types_tuple) {
+  const T max = std::numeric_limits<T>::max();
+  BOOST_CHECK_EQUAL(true,  ba::is_clamped( max, max, max ));
+  BOOST_CHECK_EQUAL(true,  ba::is_clamped( max, max - 1, max ));
+  BOOST_CHECK_EQUAL(false, ba::is_clamped( max - 1, max, max ));
+
+  const T min = std::numeric_limits<T>::min();
+  BOOST_CHECK_EQUAL(true,  ba::is_clamped( min, min, min ));
+  BOOST_CHECK_EQUAL(true,  ba::is_clamped( min, min, min + 1 ));
+  BOOST_CHECK_EQUAL(false, ba::is_clamped( min, min + 1, min + 1 ));
+}
+#endif

--- a/test/is_clamped_test.cpp
+++ b/test/is_clamped_test.cpp
@@ -1,4 +1,4 @@
-﻿//  (C) Copyright TODO
+﻿//  (C) Copyright Ivan Matek, Marshall Clow 2021.
 //  Use, modification and distribution are subject to the
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)


### PR DESCRIPTION
Hi, 
this is example code for addition of `is_clamped`.

I have never committed to boost, I asked on boost mailing list how to proceed if I want to add `is_clamped `and this was a suggested way to do it.

I did not update the docs, since I first wanted to get a feedback if there is interest in this. 

Few other points.

1.  naming: `is_clamped `is symmetric in STL kind of way but maybe some people would prefer is_between or some other name
2.  formatting: is there some way to automatically format code(like clang-format), it was quite tricky for me to emulate the style of clamp_test.cpp
3. there was(is?) [proposal](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1440r0.html) for std::is_clamped, I am not related to that
4. I have test for `std::string`, normally people use this with numeric types, but I see nothing in docs for clamp preventing the use of types like std::string
5. I have no idea what to put in Copyright/Author comments, and I did not want to spend too much time investigating this, most important thing is if there is interest in this algorithm or not.
6. I have created separate file(both include and test) for this, not sure if you prefer to keep it all in clamp.hpp, again did not want to spend too much time investigating this since it is relatively simple change if there is interest in this algorithm.
7. I have personally needed this algorithm a few times during past few years in my job, but not sure if there is some widespread need for it.