### PR TITLE
Fix -Wdeprecated-copy warnings in string algorithms

### DIFF
--- a/include/boost/algorithm/string/detail/find_iterator.hpp
+++ b/include/boost/algorithm/string/detail/find_iterator.hpp
@@ -40,10 +40,18 @@ namespace boost {
             // Protected construction/destruction
 
                 // Default constructor
-                find_iterator_base() {}
+                BOOST_DEFAULTED_FUNCTION(find_iterator_base(), {})
+
                 // Copy construction
-                find_iterator_base( const find_iterator_base& Other ) :
+                BOOST_DEFAULTED_FUNCTION(find_iterator_base( const find_iterator_base& Other ), :
                     m_Finder(Other.m_Finder) {}
+                )
+
+                // Assignment
+                BOOST_DEFAULTED_FUNCTION(find_iterator_base& operator=( const find_iterator_base& Other ), {
+                    m_Finder = Other.m_Finder;
+                    return *this;
+                })
                 
                 // Constructor
                 template<typename FinderT>
@@ -51,7 +59,7 @@ namespace boost {
                     m_Finder(Finder) {}
 
                 // Destructor
-                ~find_iterator_base() {}
+                BOOST_DEFAULTED_FUNCTION(~find_iterator_base(), {})
 
                 // Find operation
                 match_type do_find( 

--- a/include/boost/algorithm/string/find_iterator.hpp
+++ b/include/boost/algorithm/string/find_iterator.hpp
@@ -74,7 +74,7 @@ namespace boost {
 
                 \post eof()==true
             */
-            find_iterator() {}
+            BOOST_DEFAULTED_FUNCTION(find_iterator(), {})
 
             //! Copy constructor
             /*!
@@ -84,6 +84,18 @@ namespace boost {
                 base_type(Other),
                 m_Match(Other.m_Match),
                 m_End(Other.m_End) {}
+
+            //! Copy assignment
+            /*!
+                Assigns a copy of the find_iterator
+            */
+            BOOST_DEFAULTED_FUNCTION(find_iterator& operator=( const find_iterator& Other ), {
+                if (this == &Other) return *this;
+                this->base_type::operator=(Other);
+                m_Match = Other.m_Match;
+                m_End = Other.m_End;
+                return *this;
+            })
 
             //! Constructor
             /*!
@@ -247,6 +259,20 @@ namespace boost {
                 m_End(Other.m_End),
                 m_bEof(Other.m_bEof)
             {}
+
+            //! Assignment operator
+            /*!
+                Assigns a copy of the split_iterator
+            */
+            BOOST_DEFAULTED_FUNCTION(split_iterator& operator=( const split_iterator& Other ), {
+                if (this == &Other) return *this;
+                this->base_type::operator=(Other);
+                m_Match = Other.m_Match;
+                m_Next = Other.m_Next;
+                m_End = Other.m_End;
+                m_bEof = Other.m_bEof;
+                return *this;
+            })
 
             //! Constructor
             /*!


### PR DESCRIPTION
Compiling algorithm/string/test with command ` ../../../../b2 cxxstd=2a "cxxflags=-Werror=deprecated-copy" toolset=gcc-9 -j4` without the patch produces warnings like the following:
```
split_test.cpp:193:14: error: implicitly-declared ‘boost::algorithm::find_iterator<__gnu_cxx::__normal_iterator<char*, std::__cxx11::basic_string<char> > >& boost::algorithm::find_iterator<__gnu_cxx::__normal_iterator<char*, std::__cxx11::basic_string<char> > >::operator=(const boost::algorithm::find_iterator<__gnu_cxx::__normal_iterator<char*, std::__cxx11::basic_string<char> > >&)’ is deprecated [-Werror=deprecated-copy]
  193 |     fiter2 = fiter;
      |              ^~~~~
```