### PR TITLE
Add is_blank() string functor classification

### DIFF
--- a/include/boost/algorithm/gather.hpp
+++ b/include/boost/algorithm/gather.hpp
@@ -1,4 +1,4 @@
-/* 
+/*
     Copyright 2008 Adobe Systems Incorporated
 
    Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -84,7 +84,7 @@ namespace boost { namespace algorithm {
 template <
     typename BidirectionalIterator,  // models BidirectionalIterator
     typename Pred>                   // models UnaryPredicate
-std::pair<BidirectionalIterator, BidirectionalIterator> gather 
+std::pair<BidirectionalIterator, BidirectionalIterator> gather
         ( BidirectionalIterator first, BidirectionalIterator last, BidirectionalIterator pivot, Pred pred )
 {
 //  The first call partitions everything up to (but not including) the pivot element,
@@ -106,11 +106,11 @@ template <
     typename BidirectionalRange,    //
     typename Pred>                  // Pred models UnaryPredicate
 std::pair<
-    typename boost::range_iterator<const BidirectionalRange>::type,
-    typename boost::range_iterator<const BidirectionalRange>::type>
+    typename boost::range_iterator<BidirectionalRange>::type,
+    typename boost::range_iterator<BidirectionalRange>::type>
 gather (
-    const BidirectionalRange &range,
-    typename boost::range_iterator<const BidirectionalRange>::type pivot,
+    BidirectionalRange &range,
+    typename boost::range_iterator<BidirectionalRange>::type pivot,
     Pred pred )
 {
     return boost::algorithm::gather ( boost::begin ( range ), boost::end ( range ), pivot, pred );

--- a/include/boost/algorithm/string/classification.hpp
+++ b/include/boost/algorithm/string/classification.hpp
@@ -85,6 +85,22 @@ namespace boost {
             return detail::is_classifiedF(std::ctype_base::alpha, Loc);
         }
 
+#ifndef BOOST_NO_CXX11
+        //! is_blank predicate
+        /*!
+            Construct the \c is_classified predicate for the \c ctype_base::blank category.
+
+            \param Loc A locale used for classification
+            \return An instance of the \c is_classified predicate
+            \since c++11
+        */
+        inline detail::is_classifiedF
+        is_blank(const std::locale& Loc=std::locale())
+        {
+            return detail::is_classifiedF(std::ctype_base::blank, Loc);
+        }
+#endif
+    
         //! is_cntrl predicate
         /*!
             Construct the \c is_classified predicate for the \c ctype_base::cntrl category.   
@@ -294,6 +310,9 @@ namespace boost {
     // pull names to the boost namespace
     using algorithm::is_classified;
     using algorithm::is_space;
+#ifndef BOOST_NO_CXX11
+    using algorithm::is_blank;
+#endif
     using algorithm::is_alnum;
     using algorithm::is_alpha;
     using algorithm::is_cntrl;

--- a/string/doc/quickref.xml
+++ b/string/doc/quickref.xml
@@ -668,6 +668,13 @@
                         </entry>
                     </row>
                     <row>
+                        <entry>is_blank</entry>
+                        <entry>Recognize blanks</entry>
+                        <entry>
+                            <functionname>is_blank()</functionname>
+                        </entry>
+                    </row>
+                    <row>
                         <entry>is_alnum</entry>
                         <entry>Recognize alphanumeric characters</entry>
                         <entry>

--- a/string/test/predicate_test.cpp
+++ b/string/test/predicate_test.cpp
@@ -138,7 +138,11 @@ void classification_test()
     TEST_CLASS( is_any_of( string("abc") ), "aaabbcc", "aaxb" );
     TEST_CLASS( is_any_of( "abc" ), "aaabbcc", "aaxb" );
     TEST_CLASS( is_from_range( 'a', 'c' ), "aaabbcc", "aaxb" );
-
+    
+#ifndef BOOST_NO_CXX11
+    TEST_CLASS( is_blank(), " \t", "\t \n\r" );
+#endif
+    
     TEST_CLASS( !is_classified(std::ctype_base::space), "...", "..\n\r\t " );
     TEST_CLASS( ( !is_any_of("abc") && is_from_range('a','e') ) || is_space(), "d e", "abcde" );
 

--- a/string/test/predicate_test.cpp
+++ b/string/test/predicate_test.cpp
@@ -141,6 +141,7 @@ void classification_test()
     
 #ifndef BOOST_NO_CXX11
     TEST_CLASS( is_blank(), " \t", "\t \n\r" );
+    TEST_CLASS( !is_blank(), "abc\n\v\f\r", "a x\t" );
 #endif
     
     TEST_CLASS( !is_classified(std::ctype_base::space), "...", "..\n\r\t " );


### PR DESCRIPTION
In string algorithm, is_blank standard classification exists since C++11. Today, this classification is not provided by this library for code.
I have added is_blank functor in the implementation compiled with standard upper or equals to c++11 and complete the documentation.