### PR TITLE
Avoid -Wdangling-pointer warning with gcc 13 and -O2

### DIFF
--- a/include/boost/algorithm/string/iter_find.hpp
+++ b/include/boost/algorithm/string/iter_find.hpp
@@ -111,7 +111,7 @@ namespace boost {
 
             SequenceSequenceT Tmp(itBegin, itEnd);
                         
-            Result.swap(Tmp);
+            Tmp.swap(Result);
             return Result;
         }
 
@@ -185,7 +185,7 @@ namespace boost {
             
             SequenceSequenceT Tmp(itBegin, itEnd);
 
-            Result.swap(Tmp);
+            Tmp.swap(Result);
             return Result;
         }
 


### PR DESCRIPTION
Apply the simple workaround described https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106238#c6 which prevents the warning from being raised while keeping the exact same semantic.

```
In member function 'std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::_Identity<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::swap(std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::_Identity<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&)',
    inlined from 'std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::swap(std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&)' at /remote/tools/Linux/2.6/1A/toolchain/x86_64-v23.0.7/include/c++/13.0.1/bits/stl_set.h:443:18,
    inlined from 'boost::algorithm::iter_split<std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, boost::algorithm::detail::token_finderF<boost::algorithm::detail::is_any_ofF<char> > >(std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, boost::algorithm::detail::token_finderF<boost::algorithm::detail::is_any_ofF<char> >)std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >& [clone .isra.0]' at /data/mwrep/res/osp/Boost/23-0-0-0/include/boost/algorithm/string/iter_find.hpp:188:24:
/remote/tools/Linux/2.6/1A/toolchain/x86_64-v23.0.7/include/c++/13.0.1/bits/stl_tree.h:2092:36: error: storing the address of local variable 'Tmp' in '_239->_M_parent' [-Werror=dangling-pointer=]
 2092 |           __t._M_root()->_M_parent = __t._M_end();
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
```