### PR TITLE
Improve is_palindrome performance significantly (C++03 compat)

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -34,6 +34,7 @@ explicit
     [ alias all : boost_algorithm test
         example
         minmax/example minmax/test
+        performance
         string/example string/test
         ]
     ;

--- a/include/boost/algorithm/is_palindrome.hpp
+++ b/include/boost/algorithm/is_palindrome.hpp
@@ -20,6 +20,7 @@
 #include <cstring>
 
 #include <boost/config.hpp>
+#include <boost/iterator/reverse_iterator.hpp>
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 
@@ -38,26 +39,9 @@ namespace boost {  namespace algorithm {
 template <typename BidirectionalIterator, typename Predicate>
 bool is_palindrome(BidirectionalIterator begin, BidirectionalIterator end, Predicate p)
 {
-    if(begin == end)
-    {
-        return true;
-    }
-
-    --end;
-    while(begin != end)
-    {
-        if(!p(*begin, *end))
-        {
-            return false;
-        }
-        ++begin;
-        if(begin == end)
-        {
-            break;
-        }
-        --end;
-    }
-    return true;
+    BidirectionalIterator midpoint = begin;
+    std::advance(midpoint, std::distance(begin, end) / 2);
+    return std::equal(begin, midpoint, boost::make_reverse_iterator(end), p);
 }
 
 /// \fn is_palindrome ( BidirectionalIterator begin, BidirectionalIterator end )

--- a/performance/Jamfile.v2
+++ b/performance/Jamfile.v2
@@ -1,0 +1,30 @@
+#==============================================================================
+#   Copyright (c) Antony Polukhin, 2012-2024.
+#   Copyright (c) James E. King III, 2025.
+#
+#   Distributed under the Boost Software License, Version 1.0. (See accompanying
+#   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#==============================================================================
+
+# performance tests
+import testing ;
+import path ;
+
+path-constant TEST_DIR : . ;
+
+project performance
+    : source-location ./
+    : requirements
+      <library>/boost/chrono//boost_chrono
+      <library>/boost/program_options//boost_program_options
+      <library>/boost/system//boost_system
+      <link>static
+      <target-os>freebsd:<linkflags>"-lrt"
+      <target-os>linux:<linkflags>"-lrt"
+      <toolset>gcc:<cxxflags>-fvisibility=hidden
+      <toolset>intel-linux:<cxxflags>-fvisibility=hidden
+      <toolset>sun:<cxxflags>-xldscope=hidden
+    : default-build release
+ ;
+
+run perf_is_palindrome.cpp : $(TEST_DIR) ;

--- a/performance/perf_is_palindrome.cpp
+++ b/performance/perf_is_palindrome.cpp
@@ -1,0 +1,82 @@
+#include <boost/algorithm/is_palindrome.hpp>
+#include <boost/chrono.hpp>
+#include <boost/program_options.hpp>
+#include <iostream>
+#include <string>
+#include <vector>
+#include <algorithm>
+
+using boost::algorithm::is_palindrome;
+namespace po = boost::program_options;
+
+void run_is_palindrome_test(size_t iterations) {
+    // Prepare test cases: small, medium, large, palindromes and non-palindromes
+    std::vector<std::string> test_cases = {
+        "madam", "racecar", "level", "hello", "world", // small
+        std::string(100, 'a'), // medium palindrome
+        std::string(42, 'a') + "b" + std::string(57, 'a'), // medium non-palindrome
+        std::string(10000, 'x'), // large palindrome
+        std::string(3248, 'y') + "z" + std::string(6751, 'y'), // large non-palindrome
+    };
+
+    // Make sure some are not palindromes
+    test_cases.push_back("abcdefg");
+    test_cases.push_back("abccba");
+    test_cases.push_back("abccbx");
+
+    // Warm up
+    volatile bool dummy = false;
+    for (const auto& s : test_cases) {
+        dummy ^= is_palindrome(s);
+    }
+
+    // Start timing
+    boost::chrono::high_resolution_clock::time_point start = boost::chrono::high_resolution_clock::now();
+
+    size_t palindrome_count = 0;
+    for (size_t i = 0; i < iterations; ++i) {
+        for (const auto& s : test_cases) {
+            if (is_palindrome(s)) {
+                ++palindrome_count;
+            }
+        }
+    }
+
+    boost::chrono::high_resolution_clock::time_point end = boost::chrono::high_resolution_clock::now();
+    boost::chrono::duration<double> elapsed = end - start;
+
+    size_t total_runs = iterations * test_cases.size();
+    double avg_time_per_run = elapsed.count() / total_runs * 1e6; // microseconds
+
+    std::cout << "Total runs: " << total_runs << std::endl;
+    std::cout << "Total palindromes found: " << palindrome_count << std::endl;
+    std::cout << "Total elapsed time: " << elapsed.count() << " seconds" << std::endl;
+    std::cout << "Average time per is_palindrome: " << avg_time_per_run << " microseconds" << std::endl;
+}
+
+int main(int argc, char* argv[]) {
+    size_t iterations = 1000000;
+
+    po::options_description desc("Allowed options");
+    desc.add_options()
+        ("help,h", "produce help message")
+        ("iterations,n", po::value<size_t>(&iterations)->default_value(1000000), "number of iterations")
+    ;
+
+    po::variables_map vm;
+    try {
+        po::store(po::parse_command_line(argc, argv, desc), vm);
+        po::notify(vm);
+    } catch (const std::exception& ex) {
+        std::cerr << "Error parsing options: " << ex.what() << std::endl;
+        return 1;
+    }
+
+    if (vm.count("help")) {
+        std::cout << desc << std::endl;
+        return 0;
+    }
+
+    run_is_palindrome_test(iterations);
+    return 0;   // this is not a correctness test; there are others for that
+}


### PR DESCRIPTION
Refactored `is_palindrome` to use std::equal yielding a 58% performance gain in limited testing (x86_64, gcc 12.2).  This has fewer branches and leverages the optimization already done on the std::equal implementation.

Before: 6.953285 secs
```
jking@pulsar:~/boost/libs/algorithm/performance$ ../../../bin.v2/libs/algorithm/performance/perf_is_palindrome.test/gcc-12/release/x86_64/link-static/perf_is_palindrome
Total runs: 12000000
Total palindromes found: 6000000
Total elapsed time: 6.95016 seconds
Average time per is_palindrome: 0.57918 microseconds
jking@pulsar:~/boost/libs/algorithm/performance$ ../../../bin.v2/libs/algorithm/performance/perf_is_palindrome.test/gcc-12/release/x86_64/link-static/perf_is_palindrome
Total runs: 12000000
Total palindromes found: 6000000
Total elapsed time: 6.95641 seconds
Average time per is_palindrome: 0.579701 microseconds
```

After: 2.915925 secs
```
jking@pulsar:~/boost/libs/algorithm/performance$ ../../../bin.v2/libs/algorithm/performance/perf_is_palindrome.test/gcc-12/release/x86_64/link-static/perf_is_palindrome
Total runs: 12000000
Total palindromes found: 6000000
Total elapsed time: 2.92422 seconds
Average time per is_palindrome: 0.243685 microseconds
jking@pulsar:~/boost/libs/algorithm/performance$ ../../../bin.v2/libs/algorithm/performance/perf_is_palindrome.test/gcc-12/release/x86_64/link-static/perf_is_palindrome
Total runs: 12000000
Total palindromes found: 6000000
Total elapsed time: 2.90763 seconds
Average time per is_palindrome: 0.242302 microseconds
```

Yielding a 58.06% performance gain.