### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ target_link_libraries(boost_algorithm
     Boost::mpl
     Boost::range
     Boost::regex
-    Boost::static_assert
     Boost::throw_exception
     Boost::tuple
     Boost::type_traits

--- a/build.jam
+++ b/build.jam
@@ -18,7 +18,6 @@ constant boost_dependencies :
     /boost/mpl//boost_mpl
     /boost/range//boost_range
     /boost/regex//boost_regex
-    /boost/static_assert//boost_static_assert
     /boost/throw_exception//boost_throw_exception
     /boost/tuple//boost_tuple
     /boost/type_traits//boost_type_traits


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.