### PR TITLE
[doc] Fix the parameter names documented for is_permutation

### DIFF
--- a/include/boost/algorithm/cxx11/is_permutation.hpp
+++ b/include/boost/algorithm/cxx11/is_permutation.hpp
@@ -100,7 +100,7 @@ namespace detail {
 }
 /// \endcond
 
-/// \fn is_permutation ( ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 first2, BinaryPredicate p )
+/// \fn is_permutation ( ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, BinaryPredicate p )
 /// \brief Tests to see if the sequence [first,last) is a permutation of the sequence starting at first2
 ///
 /// \param first1   The start of the input sequence
@@ -127,11 +127,11 @@ bool is_permutation ( ForwardIterator1 first1, ForwardIterator1 last1,
     return true;
 }
 
-/// \fn is_permutation ( ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 first2 )
+/// \fn is_permutation ( ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2 )
 /// \brief Tests to see if the sequence [first,last) is a permutation of the sequence starting at first2
 ///
 /// \param first1   The start of the input sequence
-/// \param last2    One past the end of the input sequence
+/// \param last1    One past the end of the input sequence
 /// \param first2   The start of the second sequence
 /// \note           This function is part of the C++2011 standard library.
 template< class ForwardIterator1, class ForwardIterator2 >


### PR DESCRIPTION
The three-argument `is_permutation` overload documents a parameter it does not have:

```cpp
/// \fn is_permutation ( ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 first2 )
///
/// \param first1   The start of the input sequence
/// \param last2    One past the end of the input sequence     <-- last1
/// \param first2   The start of the second sequence
template< class ForwardIterator1, class ForwardIterator2 >
bool is_permutation ( ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2 )
```

`last2` is not a parameter — it is a local variable computed inside the body (`ForwardIterator2 last2 = first2; std::advance(...)`), which is presumably how it got into the comment. The four-argument overload twenty lines above documents `last1` correctly, so the two overloads describe the same parameter differently.

Both `\fn` lines in the file also spell the first two parameters `first` and `last`, while the declarations use `first1` and `last1`. Doxygen matches `\fn` against the declaration, so those names should agree too.

Comments only, one file.

## Found while sweeping, not included

The same check — every `\param`/`\tparam` name in a Doxygen block against the actual signature — turns up a few more in this library and its neighbours:

- `boost/algorithm/string/formatter.hpp`, `empty_formatter` documents `\param Input` while the parameter in the declaration is unnamed (`empty_formatter(const RangeT&)`).
- Boost.GIL has 42 such mismatches, Boost.Histogram 25, mostly `\param` names that were renamed in the signature.

I kept this PR to `is_permutation`. **If the rest is worth fixing, say so in a comment and I will send them** — per library, so each stays reviewable — or tell me a given one is intentional and I will leave it alone.
