### PR TITLE
Fix \fn and \param tags in the searching algorithms

### DIFF
--- a/include/boost/algorithm/searching/boyer_moore.hpp
+++ b/include/boost/algorithm/searching/boyer_moore.hpp
@@ -108,12 +108,11 @@ Requirements:
         typename traits::skip_table_t skip_;
         std::vector <difference_type> suffix_;
 
-        /// \fn operator ( corpusIter corpus_first, corpusIter corpus_last, Pred p )
+        /// \fn do_search ( corpusIter corpus_first, corpusIter corpus_last )
         /// \brief Searches the corpus for the pattern that was passed into the constructor
-        /// 
+        ///
         /// \param corpus_first The start of the data to search (Random Access Iterator)
         /// \param corpus_last  One past the end of the data to search
-        /// \param p            A predicate used for the search comparisons.
         ///
         template <typename corpusIter>
         std::pair<corpusIter, corpusIter>

--- a/include/boost/algorithm/searching/boyer_moore_horspool.hpp
+++ b/include/boost/algorithm/searching/boyer_moore_horspool.hpp
@@ -107,7 +107,6 @@ http://www-igm.univ-mlv.fr/%7Elecroq/string/node18.html
         /// 
         /// \param corpus_first The start of the data to search (Random Access Iterator)
         /// \param corpus_last  One past the end of the data to search
-        /// \param k_corpus_length The length of the corpus to search
         ///
         template <typename corpusIter>
         std::pair<corpusIter, corpusIter>

--- a/include/boost/algorithm/searching/knuth_morris_pratt.hpp
+++ b/include/boost/algorithm/searching/knuth_morris_pratt.hpp
@@ -62,12 +62,11 @@ namespace boost { namespace algorithm {
             
         ~knuth_morris_pratt () {}
         
-        /// \fn operator ( corpusIter corpus_first, corpusIter corpus_last, Pred p )
+        /// \fn operator ( corpusIter corpus_first, corpusIter corpus_last )
         /// \brief Searches the corpus for the pattern that was passed into the constructor
-        /// 
+        ///
         /// \param corpus_first The start of the data to search (Random Access Iterator)
         /// \param corpus_last  One past the end of the data to search
-        /// \param p            A predicate used for the search comparisons.
         ///
         template <typename corpusIter>
         std::pair<corpusIter, corpusIter>
@@ -99,16 +98,16 @@ namespace boost { namespace algorithm {
         const difference_type k_pattern_length;
         std::vector <difference_type> skip_;
 
-        /// \fn operator ( corpusIter corpus_first, corpusIter corpus_last, Pred p )
+        /// \fn do_search ( corpusIter corpus_first, corpusIter corpus_last, difference_type k_corpus_length )
         /// \brief Searches the corpus for the pattern that was passed into the constructor
-        /// 
+        ///
         /// \param corpus_first The start of the data to search (Random Access Iterator)
         /// \param corpus_last  One past the end of the data to search
-        /// \param p            A predicate used for the search comparisons.
+        /// \param k_corpus_length The length of the corpus to search
         ///
         template <typename corpusIter>
         std::pair<corpusIter, corpusIter>
-        do_search ( corpusIter corpus_first, corpusIter corpus_last, 
+        do_search ( corpusIter corpus_first, corpusIter corpus_last,
                                                 difference_type k_corpus_length ) const {
             difference_type match_start = 0;  // position in the corpus that we're matching
             


### PR DESCRIPTION
The four searchers share copied comment blocks, and three of them kept names from a function they no longer describe. Documentation only, no code touched.

| Where | What the comment says | What the code takes |
|---|---|---|
| `knuth_morris_pratt.hpp:65` | `\fn operator (corpus_first, corpus_last, Pred p)`, plus `\param p` | `operator () (corpusIter corpus_first, corpusIter corpus_last)` |
| `knuth_morris_pratt.hpp:102` | same block again, on a different function | `do_search (corpus_first, corpus_last, difference_type k_corpus_length)` |
| `boyer_moore.hpp:111` | `\fn operator (..., Pred p)`, plus `\param p` | `do_search (corpus_first, corpus_last)` |
| `boyer_moore_horspool.hpp:105` | `\param k_corpus_length` | `do_search (corpus_first, corpus_last)` |

Three things going on, all from the same copying:

- A predicate parameter `Pred p` is documented in two files. No operator or `do_search` in either of them takes one, and `Pred` does not appear anywhere else in those headers.
- Two blocks are named `\fn operator` while sitting on `do_search`.
- In `knuth_morris_pratt.hpp:102` the function does take a third parameter, but it is `k_corpus_length`, not `p`. That one I filled in rather than removed.

The correct form is already next door: `boyer_moore.hpp:73` and `boyer_moore_horspool.hpp:68` both name two parameters and no predicate, so this brings the rest in line with them.

Three of the four sit inside `\cond DOXYGEN_HIDE`, so they do not reach the generated docs today. I fixed them anyway since the block is a few lines from the visible one and reads as a template for it.

Not in this pull request: `string/formatter.hpp:74` documents `\param Input` on `empty_formatter(const RangeT&)`, whose parameter has no name. That is a different kind of change and I did not want to mix it in. I can send it separately if you want it.
